### PR TITLE
Renamed `oci_image` attributes to `image`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,8 @@ bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "stardoc", version = "0.6.2", repo_name = "io_bazel_stardoc")
 bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_oci", version = "1.2.0")
+
+# This is unfortunately requried by `rules_oci`.
 bazel_dep(name = "aspect_bazel_lib", version = "1.34.0")
 
 helm = use_extension("@rules_helm//helm:extensions.bzl", "helm")
@@ -24,7 +26,7 @@ use_repo(
     "helm_windows_amd64_toolchain",
 )
 use_repo(helm, "go_yaml_yaml")
-use_repo(helm, "helm_test_deps__with_chart_deps", "rules_helm_test_oci_container_base")
+use_repo(helm, "helm_test_deps__with_chart_deps", "rules_helm_test_container_base")
 
 register_toolchains(
     "@helm_darwin_amd64_toolchain//:toolchain",

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ A rule for performing `helm lint` on a helm package
 ## helm_package
 
 <pre>
-helm_package(<a href="#helm_package-name">name</a>, <a href="#helm_package-deps">deps</a>, <a href="#helm_package-chart">chart</a>, <a href="#helm_package-chart_json">chart_json</a>, <a href="#helm_package-oci_images">oci_images</a>, <a href="#helm_package-stamp">stamp</a>, <a href="#helm_package-templates">templates</a>, <a href="#helm_package-values">values</a>, <a href="#helm_package-values_json">values_json</a>)
+helm_package(<a href="#helm_package-name">name</a>, <a href="#helm_package-deps">deps</a>, <a href="#helm_package-chart">chart</a>, <a href="#helm_package-chart_json">chart_json</a>, <a href="#helm_package-images">images</a>, <a href="#helm_package-stamp">stamp</a>, <a href="#helm_package-templates">templates</a>, <a href="#helm_package-values">values</a>, <a href="#helm_package-values_json">values_json</a>)
 </pre>
 
 
@@ -148,7 +148,7 @@ helm_package(<a href="#helm_package-name">name</a>, <a href="#helm_package-deps"
 | <a id="helm_package-deps"></a>deps |  Other helm packages this package depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="helm_package-chart"></a>chart |  The `Chart.yaml` file of the helm chart   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="helm_package-chart_json"></a>chart_json |  A json encoded string to use as the `Chart.yaml` file of the helm chart   | String | optional |  `""`  |
-| <a id="helm_package-oci_images"></a>oci_images |  [@rules_oci//oci:defs.bzl%oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags) targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="helm_package-images"></a>images |  [@rules_oci//oci:defs.bzl%oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags) targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="helm_package-stamp"></a>stamp |  Whether to encode build information into the helm actions. Possible values:<br><br>- `stamp = 1`: Always stamp the build information into the helm actions, even in                 [--nostamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) builds.                 This setting should be avoided, since it potentially kills remote caching for the target and                 any downstream actions that depend on it.<br><br>- `stamp = 0`: Always replace build information by constant values. This gives good build result caching.<br><br>- `stamp = -1`: Embedding of build information is controlled by the                 [--[no]stamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) flag.<br><br>Stamped targets are not rebuilt unless their dependencies change.   | Integer | optional |  `-1`  |
 | <a id="helm_package-templates"></a>templates |  All templates associated with the current helm chart. E.g., the `./templates` directory   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="helm_package-values"></a>values |  The `values.yaml` file for the current package. This attribute is mutally exclusive with `values_json`.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
@@ -237,7 +237,7 @@ Produce a script for performing a helm uninstall action
 ## HelmPackageInfo
 
 <pre>
-HelmPackageInfo(<a href="#HelmPackageInfo-chart">chart</a>, <a href="#HelmPackageInfo-metadata">metadata</a>, <a href="#HelmPackageInfo-oci_images">oci_images</a>)
+HelmPackageInfo(<a href="#HelmPackageInfo-chart">chart</a>, <a href="#HelmPackageInfo-images">images</a>, <a href="#HelmPackageInfo-metadata">metadata</a>)
 </pre>
 
 A provider for helm packages
@@ -248,8 +248,8 @@ A provider for helm packages
 | Name  | Description |
 | :------------- | :------------- |
 | <a id="HelmPackageInfo-chart"></a>chart |  File: The result of `helm package`    |
+| <a id="HelmPackageInfo-images"></a>images |  list[Target]: A list of [@rules_oci//oci:defs.bzl%oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags)]) targets    |
 | <a id="HelmPackageInfo-metadata"></a>metadata |  File: A json encoded file containing metadata about the helm chart    |
-| <a id="HelmPackageInfo-oci_images"></a>oci_images |  list[Target]: A list of [@rules_oci//oci:defs.bzl%oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags)]) targets    |
 
 
 <a id="chart_content"></a>
@@ -284,7 +284,7 @@ str: A json encoded string which represents `Chart.yaml` contents.
 ## helm_chart
 
 <pre>
-helm_chart(<a href="#helm_chart-name">name</a>, <a href="#helm_chart-oci_images">oci_images</a>, <a href="#helm_chart-deps">deps</a>, <a href="#helm_chart-tags">tags</a>, <a href="#helm_chart-install_name">install_name</a>, <a href="#helm_chart-kwargs">kwargs</a>)
+helm_chart(<a href="#helm_chart-name">name</a>, <a href="#helm_chart-images">images</a>, <a href="#helm_chart-deps">deps</a>, <a href="#helm_chart-tags">tags</a>, <a href="#helm_chart-install_name">install_name</a>, <a href="#helm_chart-kwargs">kwargs</a>)
 </pre>
 
 Rules for producing a helm package and some convenience targets.
@@ -304,7 +304,7 @@ Rules for producing a helm package and some convenience targets.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="helm_chart-name"></a>name |  The name of the [helm_package](#helm_package) target.   |  none |
-| <a id="helm_chart-oci_images"></a>oci_images |  A list of [oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags) targets   |  `[]` |
+| <a id="helm_chart-images"></a>images |  A list of [oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags) targets   |  `[]` |
 | <a id="helm_chart-deps"></a>deps |  A list of helm package dependencies.   |  `None` |
 | <a id="helm_chart-tags"></a>tags |  Tags to apply to all targets.   |  `[]` |
 | <a id="helm_chart-install_name"></a>install_name |  The `helm install` name to use. `name` will be used if unset.   |  `None` |

--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -3,7 +3,7 @@
 load("//helm/private:helm_install.bzl", "helm_install", "helm_push", "helm_reinstall", "helm_uninstall")
 load("//helm/private:helm_package.bzl", "helm_package")
 
-def helm_chart(name, oci_images = [], deps = None, tags = [], install_name = None, **kwargs):
+def helm_chart(name, images = [], deps = None, tags = [], install_name = None, **kwargs):
     """Rules for producing a helm package and some convenience targets.
 
     | target | rule |
@@ -16,7 +16,7 @@ def helm_chart(name, oci_images = [], deps = None, tags = [], install_name = Non
 
     Args:
         name (str): The name of the [helm_package](#helm_package) target.
-        oci_images (list, optional): A list of [oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags) targets
+        images (list, optional): A list of [oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags) targets
         deps (list, optional): A list of helm package dependencies.
         tags (list, optional): Tags to apply to all targets.
         install_name (str, optional): The `helm install` name to use. `name` will be used if unset.
@@ -26,7 +26,7 @@ def helm_chart(name, oci_images = [], deps = None, tags = [], install_name = Non
         name = name,
         chart = "Chart.yaml",
         deps = deps,
-        oci_images = oci_images,
+        images = images,
         tags = tags,
         templates = native.glob(["templates/**"]),
         values = "values.yaml",

--- a/helm/private/helm_import.bzl
+++ b/helm/private/helm_import.bzl
@@ -19,7 +19,7 @@ def _helm_import_impl(ctx):
         ),
         HelmPackageInfo(
             chart = ctx.file.chart,
-            oci_images = [],
+            images = [],
             metadata = metadata_output,
         ),
     ]

--- a/helm/private/helm_install.bzl
+++ b/helm/private/helm_install.bzl
@@ -14,11 +14,11 @@ def _helm_install_impl(ctx):
 
     pkg_info = ctx.attr.package[HelmPackageInfo]
 
-    oci_image_pushers = []
-    oci_image_runfiles = []
-    for oci_image in pkg_info.oci_images:
-        oci_image_pushers.append(oci_image[DefaultInfo].files_to_run.executable)
-        oci_image_runfiles.append(oci_image[DefaultInfo].default_runfiles)
+    image_pushers = []
+    image_runfiles = []
+    for image in pkg_info.images:
+        image_pushers.append(image[DefaultInfo].files_to_run.executable)
+        image_runfiles.append(image[DefaultInfo].default_runfiles)
 
     ctx.actions.expand_template(
         template = ctx.file._installer,
@@ -26,14 +26,14 @@ def _helm_install_impl(ctx):
         substitutions = {
             "{chart}": pkg_info.chart.short_path,
             "{helm}": toolchain.helm.short_path,
+            "{image_pushers}": "\n".join([pusher.short_path for pusher in image_pushers]),
             "{install_name}": install_name,
-            "{oci_image_pushers}": "\n".join([pusher.short_path for pusher in oci_image_pushers]),
         },
         is_executable = True,
     )
 
-    runfiles = ctx.runfiles([installer, toolchain.helm, pkg_info.chart] + oci_image_pushers)
-    for ir in oci_image_runfiles:
+    runfiles = ctx.runfiles([installer, toolchain.helm, pkg_info.chart] + image_pushers)
+    for ir in image_runfiles:
         runfiles = runfiles.merge(ir)
 
     return [
@@ -127,11 +127,11 @@ def _helm_reinstall_impl(ctx):
 
     pkg_info = ctx.attr.package[HelmPackageInfo]
 
-    oci_image_pushers = []
-    oci_image_runfiles = []
-    for oci_image in pkg_info.oci_images:
-        oci_image_pushers.append(oci_image[DefaultInfo].files_to_run.executable)
-        oci_image_runfiles.append(oci_image[DefaultInfo].default_runfiles)
+    image_pushers = []
+    image_runfiles = []
+    for image in pkg_info.images:
+        image_pushers.append(image[DefaultInfo].files_to_run.executable)
+        image_runfiles.append(image[DefaultInfo].default_runfiles)
 
     ctx.actions.expand_template(
         template = ctx.file._reinstaller,
@@ -139,14 +139,14 @@ def _helm_reinstall_impl(ctx):
         substitutions = {
             "{chart}": pkg_info.chart.short_path,
             "{helm}": toolchain.helm.short_path,
+            "{image_pushers}": "\n".join([pusher.short_path for pusher in image_pushers]),
             "{install_name}": install_name,
-            "{oci_image_pushers}": "\n".join([pusher.short_path for pusher in oci_image_pushers]),
         },
         is_executable = True,
     )
 
-    runfiles = ctx.runfiles([reinstaller, toolchain.helm, pkg_info.chart] + oci_image_pushers)
-    for ir in oci_image_runfiles:
+    runfiles = ctx.runfiles([reinstaller, toolchain.helm, pkg_info.chart] + image_pushers)
+    for ir in image_runfiles:
         runfiles = runfiles.merge(ir)
 
     return [
@@ -191,28 +191,28 @@ def _helm_push_impl(ctx):
 
     pkg_info = ctx.attr.package[HelmPackageInfo]
 
-    oci_image_pushers = []
-    oci_image_runfiles = []
-    for oci_image in pkg_info.oci_images:
-        oci_image_pushers.append(oci_image[DefaultInfo].files_to_run.executable)
-        oci_image_runfiles.append(oci_image[DefaultInfo].default_runfiles)
+    image_pushers = []
+    image_runfiles = []
+    for image in pkg_info.images:
+        image_pushers.append(image[DefaultInfo].files_to_run.executable)
+        image_runfiles.append(image[DefaultInfo].default_runfiles)
 
-    if oci_image_pushers:
-        oci_image_commands = "\n".join([pusher.short_path for pusher in oci_image_pushers])
+    if image_pushers:
+        image_commands = "\n".join([pusher.short_path for pusher in image_pushers])
     else:
-        oci_image_commands = "echo 'No OCI images to push for Helm chart'"
+        image_commands = "echo 'No OCI images to push for Helm chart'"
 
     ctx.actions.expand_template(
         template = ctx.file._pusher,
         output = pusher,
         substitutions = {
-            "{oci_image_pushers}": oci_image_commands,
+            "{image_pushers}": image_commands,
         },
         is_executable = True,
     )
 
-    runfiles = ctx.runfiles([pusher] + oci_image_pushers)
-    for ir in oci_image_runfiles:
+    runfiles = ctx.runfiles([pusher] + image_pushers)
+    for ir in image_runfiles:
         runfiles = runfiles.merge(ir)
 
     return [

--- a/helm/private/helm_package.bzl
+++ b/helm/private/helm_package.bzl
@@ -91,12 +91,12 @@ def _helm_package_impl(ctx):
 
     # Create documents for each image the package depends on
     image_inputs = []
-    if ctx.attr.oci_images:
+    if ctx.attr.images:
         single_image_manifests = []
-        for image in ctx.attr.oci_images:
+        for image in ctx.attr.images:
             single_image_manifest = ctx.actions.declare_file("{}/{}".format(
                 ctx.label.name,
-                str(image.label).strip("@").replace("/", "_").replace(":", "_") + ".oci_image_manifest",
+                str(image.label).strip("@").replace("/", "_").replace(":", "_") + ".image_manifest",
             ))
             push_info = image[DefaultInfo]
             ctx.actions.write(
@@ -111,14 +111,14 @@ def _helm_package_impl(ctx):
             image_inputs.extend(push_info.default_runfiles.files.to_list())
             single_image_manifests.append(single_image_manifest)
 
-        image_manifest = ctx.actions.declare_file("{}/oci_image_manifest.json".format(ctx.label.name))
+        image_manifest = ctx.actions.declare_file("{}/image_manifest.json".format(ctx.label.name))
         ctx.actions.write(
             output = image_manifest,
             content = json.encode_indent([manifest.path for manifest in single_image_manifests], indent = " " * 4),
         )
         image_inputs.append(image_manifest)
         image_inputs.extend(single_image_manifests)
-        args.add("-oci_image_manifest", image_manifest)
+        args.add("-image_manifest", image_manifest)
     stamps = []
     if is_stamping_enabled(ctx.attr):
         args.add("-volatile_status_file", ctx.version_file)
@@ -149,7 +149,7 @@ def _helm_package_impl(ctx):
         HelmPackageInfo(
             chart = output,
             metadata = metadata_output,
-            oci_images = ctx.attr.oci_images,
+            images = ctx.attr.images,
         ),
     ]
 
@@ -168,7 +168,7 @@ helm_package = rule(
             doc = "Other helm packages this package depends on.",
             providers = [HelmPackageInfo],
         ),
-        "oci_images": attr.label_list(
+        "images": attr.label_list(
             doc = "[@rules_oci//oci:defs.bzl%oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags) targets.",
         ),
         "stamp": attr.int(

--- a/helm/private/installer/helm_install.bat.template
+++ b/helm/private/installer/helm_install.bat.template
@@ -1,5 +1,5 @@
 ECHO OFF
 
-{oci_image_pushers}
+{image_pushers}
 
 {helm} install {install_name} {chart} %@%

--- a/helm/private/installer/helm_install.sh.template
+++ b/helm/private/installer/helm_install.sh.template
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-{oci_image_pushers}
+{image_pushers}
 
 eval exec {helm} install {install_name} {chart} "$@"

--- a/helm/private/pusher/helm_push.bat.template
+++ b/helm/private/pusher/helm_push.bat.template
@@ -1,3 +1,3 @@
 ECHO OFF
 
-{oci_image_pushers}
+{image_pushers}

--- a/helm/private/pusher/helm_push.sh.template
+++ b/helm/private/pusher/helm_push.sh.template
@@ -2,4 +2,4 @@
 
 set -euo pipefail
 
-{oci_image_pushers}
+{image_pushers}

--- a/helm/private/reinstaller/helm_reinstall.bat.template
+++ b/helm/private/reinstaller/helm_reinstall.bat.template
@@ -1,6 +1,6 @@
 ECHO OFF
 
-{oci_image_pushers}
+{image_pushers}
 
 {helm} uninstall {install_name}
 {helm} install {install_name} {chart} %@%

--- a/helm/private/reinstaller/helm_reinstall.sh.template
+++ b/helm/private/reinstaller/helm_reinstall.sh.template
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-{oci_image_pushers}
+{image_pushers}
 
 eval {helm} uninstall {install_name}
 eval {helm} install {install_name} {chart} "$@"

--- a/helm/providers.bzl
+++ b/helm/providers.bzl
@@ -4,7 +4,7 @@ HelmPackageInfo = provider(
     doc = "A provider for helm packages",
     fields = {
         "chart": "File: The result of `helm package`",
+        "images": "list[Target]: A list of [@rules_oci//oci:defs.bzl%oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags)]) targets",
         "metadata": "File: A json encoded file containing metadata about the helm chart",
-        "oci_images": "list[Target]: A list of [@rules_oci//oci:defs.bzl%oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags)]) targets",
     },
 )

--- a/tests/test_deps.bzl
+++ b/tests/test_deps.bzl
@@ -14,7 +14,7 @@ def helm_test_deps():
     )
 
     oci_pull(
-        name = "rules_helm_test_oci_container_base",
+        name = "rules_helm_test_container_base",
         digest = "sha256:2042a492bcdd847a01cd7f119cd48caa180da696ed2aedd085001a78664407d6",
         image = "alpine",
     )

--- a/tests/with_image_deps/BUILD.bazel
+++ b/tests/with_image_deps/BUILD.bazel
@@ -5,9 +5,9 @@ exports_files(["Chart.lock"])
 
 helm_chart(
     name = "with_image_deps",
-    oci_images = [
-        ":oci_image_a.push",
-        ":oci_image_b.push",
+    images = [
+        ":image_a.push",
+        ":image_b.push",
     ],
 )
 
@@ -23,16 +23,16 @@ _IMAGES = [
 
 [
     oci_image(
-        name = "oci_{}".format(name),
-        base = "@rules_helm_test_oci_container_base",
+        name = name,
+        base = "@rules_helm_test_container_base",
     )
     for name in _IMAGES
 ]
 
 [
     oci_push(
-        name = "oci_{}.push".format(name),
-        image = ":oci_{}".format(name),
+        name = "{}.push".format(name),
+        image = ":{}".format(name),
         remote_tags = ["latest"],
         repository = "docker.io/rules_helm/test/{}".format(name),
     )

--- a/tests/with_image_deps/values.yaml
+++ b/tests/with_image_deps/values.yaml
@@ -16,9 +16,9 @@ bazel_produced_images:
   image_b:
     url: "{@//tests/with_image_deps:image_b.push}"
   image_oci_a:
-    url: "{@//tests/with_image_deps:oci_image_a.push}"
+    url: "{@//tests/with_image_deps:image_a.push}"
   image_oci_b:
-    url: "{@//tests/with_image_deps:oci_image_b.push}"
+    url: "{@//tests/with_image_deps:image_b.push}"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This allows for easier upgrades to the `rules_oci` supported releases