### PR TITLE
Change test directory for bazel-central-repository tests

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,9 +1,8 @@
 ---
 bcr_test_module:
-  module_path: "e2e/bzlmod"
   matrix:
     # TODO(abrisco/rules_helm#1): Add windows support
-    platform: ["debian10", "macos", "ubuntu2004"]
+    platform: ["macos", "ubuntu2004"]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
Ideally there'd be an integration test within the repo that tests consuming the rules via bzl mod. For now this aims to release something in the short-term.