### PR TITLE
Add an aspect to figure out the repository name of container images.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ bazel_dep(name = "platforms", version = "0.0.5")
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "stardoc", version = "0.6.2", repo_name = "io_bazel_stardoc")
 bazel_dep(name = "rules_go", version = "0.39.1", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "rules_oci", version = "1.2.0")
+bazel_dep(name = "rules_oci", version = "1.6.0")
 
 # This is unfortunately requried by `rules_oci`.
 bazel_dep(name = "aspect_bazel_lib", version = "1.34.0")

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ A rule for performing `helm lint` on a helm package
 helm_package(<a href="#helm_package-name">name</a>, <a href="#helm_package-deps">deps</a>, <a href="#helm_package-chart">chart</a>, <a href="#helm_package-chart_json">chart_json</a>, <a href="#helm_package-images">images</a>, <a href="#helm_package-stamp">stamp</a>, <a href="#helm_package-templates">templates</a>, <a href="#helm_package-values">values</a>, <a href="#helm_package-values_json">values_json</a>)
 </pre>
 
-
+Rules for creating Helm chart packages.
 
 **ATTRIBUTES**
 
@@ -155,7 +155,7 @@ helm_package(<a href="#helm_package-name">name</a>, <a href="#helm_package-deps"
 | <a id="helm_package-deps"></a>deps |  Other helm packages this package depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="helm_package-chart"></a>chart |  The `Chart.yaml` file of the helm chart   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="helm_package-chart_json"></a>chart_json |  A json encoded string to use as the `Chart.yaml` file of the helm chart   | String | optional |  `""`  |
-| <a id="helm_package-images"></a>images |  [@rules_oci//oci:defs.bzl%oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags) targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="helm_package-images"></a>images |  A list of                 [oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags)                 targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="helm_package-stamp"></a>stamp |  Whether to encode build information into the helm actions. Possible values:<br><br>- `stamp = 1`: Always stamp the build information into the helm actions, even in                 [--nostamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) builds.                 This setting should be avoided, since it potentially kills remote caching for the target and                 any downstream actions that depend on it.<br><br>- `stamp = 0`: Always replace build information by constant values. This gives good build result caching.<br><br>- `stamp = -1`: Embedding of build information is controlled by the                 [--[no]stamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) flag.<br><br>Stamped targets are not rebuilt unless their dependencies change.   | Integer | optional |  `-1`  |
 | <a id="helm_package-templates"></a>templates |  All templates associated with the current helm chart. E.g., the `./templates` directory   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="helm_package-values"></a>values |  The `values.yaml` file for the current package. This attribute is mutally exclusive with `values_json`.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -18,9 +18,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_oci",
-    sha256 = "176e601d21d1151efd88b6b027a24e782493c5d623d8c6211c7767f306d655c8",
-    strip_prefix = "rules_oci-1.2.0",
-    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.2.0/rules_oci-v1.2.0.tar.gz",
+    sha256 = "58b7a175ee90c12583afeca388523adf6a4e5a0528f330b41c302b91a4d6fc06",
+    strip_prefix = "rules_oci-1.6.0",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.6.0/rules_oci-v1.6.0.tar.gz",
 )
 
 load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")

--- a/helm/private/json_to_yaml/json_to_yaml.go
+++ b/helm/private/json_to_yaml/json_to_yaml.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"path"
 
 	"gopkg.in/yaml.v3"
 )
@@ -27,6 +28,11 @@ func main() {
 	}
 
 	yaml_content, err := yaml.Marshal(&json_obj)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = os.MkdirAll(path.Dir(*output), 0755)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tests/with_image_deps/BUILD.bazel
+++ b/tests/with_image_deps/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("//helm:defs.bzl", "helm_chart", "helm_lint_test")
 load("//tests:test_defs.bzl", "helm_package_regex_test")
@@ -8,7 +9,7 @@ helm_chart(
     name = "with_image_deps",
     images = [
         ":image_a.push",
-        ":image_b.push",
+        "//tests/with_image_deps:image_b.push",
     ],
 )
 
@@ -39,12 +40,22 @@ _IMAGES = [
     for name in _IMAGES
 ]
 
-[
-    oci_push(
-        name = "{}.push".format(name),
-        image = ":{}".format(name),
-        remote_tags = ["latest"],
-        repository = "docker.io/rules_helm/test/{}".format(name),
-    )
-    for name in _IMAGES
-]
+oci_push(
+    name = "image_a.push",
+    image = ":image_a",
+    remote_tags = ["latest"],
+    repository = "docker.io/rules_helm/test/image_a",
+)
+
+write_file(
+    name = "image_b.repository",
+    out = "image_b.repository.txt",
+    content = ["docker.io/rules_helm/test/image_b"],
+)
+
+oci_push(
+    name = "image_b.push",
+    image = ":image_b",
+    remote_tags = ["latest"],
+    repository_file = ":image_b.repository.txt",
+)


### PR DESCRIPTION
This PR adds an aspect to figure out the repository name of container images. `images` is now a dict where the key is a oci_push target and the value is the replacement string to be found in the values.yaml. All images must be found in the values.yaml.

This also updates packager.go to use idiomatic go and go error handling.