### PR TITLE
Support older versions of golang

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ bazel_dep(name = "rules_oci", version = "1.7.2")
 bazel_dep(name = "aspect_bazel_lib", version = "1.36.0")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.22.0")
+go_sdk.download(version = "1.18.10")
 
 helm = use_extension("@rules_helm//helm:extensions.bzl", "helm")
 helm.options()

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,6 +1,6 @@
 {
   "lockFileVersion": 3,
-  "moduleFileHash": "0e8346a7326770eb4151420c5a854a7f4e38e0933fb788e4a233f15f8387a10b",
+  "moduleFileHash": "669b417c36989acbad382c4f18a9094329f6a1a7948fe194b446edf1d98fb7db",
   "flags": {
     "cmdRegistries": [
       "https://bcr.bazel.build/"
@@ -18,7 +18,7 @@
   "moduleDepGraph": {
     "<root>": {
       "name": "rules_helm",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "key": "<root>",
       "repoName": "rules_helm",
       "executionPlatformsToRegister": [],
@@ -45,7 +45,7 @@
             {
               "tagName": "download",
               "attributeValues": {
-                "version": "1.22.0"
+                "version": "1.18.10"
               },
               "devDependency": false,
               "location": {
@@ -2251,7 +2251,7 @@
               "urls": [
                 "https://dl.google.com/go/{}"
               ],
-              "version": "1.22.0"
+              "version": "1.18.10"
             }
           },
           "rules_helm__download_0_windows_arm64": {
@@ -2265,7 +2265,7 @@
               "urls": [
                 "https://dl.google.com/go/{}"
               ],
-              "version": "1.22.0"
+              "version": "1.18.10"
             }
           },
           "go_host_compatible_sdk_label": {
@@ -2301,7 +2301,7 @@
               "urls": [
                 "https://dl.google.com/go/{}"
               ],
-              "version": "1.22.0"
+              "version": "1.18.10"
             }
           },
           "go_toolchains": {
@@ -2380,12 +2380,12 @@
                 "remote"
               ],
               "sdk_versions": [
-                "1.22.0",
-                "1.22.0",
-                "1.22.0",
-                "1.22.0",
-                "1.22.0",
-                "1.22.0",
+                "1.18.10",
+                "1.18.10",
+                "1.18.10",
+                "1.18.10",
+                "1.18.10",
+                "1.18.10",
                 "1.21.1",
                 "1.21.1",
                 "1.21.1",
@@ -2406,7 +2406,7 @@
               "urls": [
                 "https://dl.google.com/go/{}"
               ],
-              "version": "1.22.0"
+              "version": "1.18.10"
             }
           },
           "io_bazel_rules_nogo": {
@@ -2449,7 +2449,7 @@
               "urls": [
                 "https://dl.google.com/go/{}"
               ],
-              "version": "1.22.0",
+              "version": "1.18.10",
               "strip_prefix": "go"
             }
           },
@@ -2510,7 +2510,7 @@
               "urls": [
                 "https://dl.google.com/go/{}"
               ],
-              "version": "1.22.0"
+              "version": "1.18.10"
             }
           },
           "rules_go__download_0_windows_amd64": {

--- a/helm/private/packager/packager.go
+++ b/helm/private/packager/packager.go
@@ -631,7 +631,7 @@ func main() {
 	// Build the helm package
 	command := exec.Command(filepath.Join(cwd, args.Helm), "package", ".")
 	command.Dir = tmpPath
-	command.Env = append(command.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
+	command.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kubeconfig))
 	out, err := command.CombinedOutput()
 	if err != nil {
 		os.Stderr.WriteString(string(out))

--- a/helm/repositories_transitive.bzl
+++ b/helm/repositories_transitive.bzl
@@ -8,4 +8,4 @@ def rules_helm_transitive_dependencies():
     go_rules_dependencies()
 
     if "go_sdk" not in native.existing_rules():
-        go_register_toolchains(go_version = "1.22.0")
+        go_register_toolchains(go_version = "1.18.10")


### PR DESCRIPTION
Use of `exec.Command.Environ` is unnecessary and increased the min supported version of golang. It's use has been removed