### PR TITLE
Fix parsing of semver according to official specification

### DIFF
--- a/helm/private/packager/packager.go
+++ b/helm/private/packager/packager.go
@@ -498,7 +498,7 @@ func findGeneratedPackage(logging string) (string, error) {
 
 func writeResultsMetadata(packageBase string, metadataOutput string) error {
 	// Official recommended regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-	re := regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$\.tgz`)
+	re := regexp.MustCompile(`(.*)-^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$\.tgz`)
 	match := re.FindAllStringSubmatch(packageBase, 2)
 
 	if len(match) == 0 {

--- a/helm/private/packager/packager.go
+++ b/helm/private/packager/packager.go
@@ -498,7 +498,7 @@ func findGeneratedPackage(logging string) (string, error) {
 
 func writeResultsMetadata(packageBase string, metadataOutput string) error {
 	// Official recommended regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-	re := regexp.MustCompile(`(.*)-^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$\.tgz`)
+	re := regexp.MustCompile(`^(.*)-(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?\.tgz$`)
 	match := re.FindAllStringSubmatch(packageBase, 2)
 
 	if len(match) == 0 {

--- a/helm/private/packager/packager.go
+++ b/helm/private/packager/packager.go
@@ -497,6 +497,7 @@ func findGeneratedPackage(logging string) (string, error) {
 }
 
 func writeResultsMetadata(packageBase string, metadataOutput string) error {
+	// Official recommended regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 	re := regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$\.tgz`)
 	match := re.FindAllStringSubmatch(packageBase, 2)
 

--- a/helm/private/packager/packager.go
+++ b/helm/private/packager/packager.go
@@ -497,7 +497,7 @@ func findGeneratedPackage(logging string) (string, error) {
 }
 
 func writeResultsMetadata(packageBase string, metadataOutput string) error {
-	re := regexp.MustCompile(`(.*)-([\d][\d\w\-\.]+)\.tgz`)
+	re := regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$\.tgz`)
 	match := re.FindAllStringSubmatch(packageBase, 2)
 
 	if len(match) == 0 {


### PR DESCRIPTION
According to [Build Metadata](https://semver.org/#spec-item-10) it should be possible to use '+' sign to annotate version with build metadata.
However, the regex [packager.go:500](https://github.com/abrisco/rules_helm/blob/8b5f89988057e54cf395c71c3d05b6e58ed843db/helm/private/packager/packager.go#L500) doesn't allow that.

Using this string as a chart version will fail: 0.0.9+63-gf336c00.