### PR TITLE
Remove manual tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,8 @@ str: A json encoded string which represents `Chart.yaml` contents.
 
 <pre>
 helm_chart(<a href="#helm_chart-name">name</a>, <a href="#helm_chart-chart">chart</a>, <a href="#helm_chart-chart_json">chart_json</a>, <a href="#helm_chart-values">values</a>, <a href="#helm_chart-values_json">values_json</a>, <a href="#helm_chart-substitutions">substitutions</a>, <a href="#helm_chart-templates">templates</a>, <a href="#helm_chart-images">images</a>, <a href="#helm_chart-deps">deps</a>,
-           <a href="#helm_chart-tags">tags</a>, <a href="#helm_chart-install_name">install_name</a>, <a href="#helm_chart-registry_url">registry_url</a>, <a href="#helm_chart-helm_opts">helm_opts</a>, <a href="#helm_chart-install_opts">install_opts</a>, <a href="#helm_chart-upgrade_opts">upgrade_opts</a>, <a href="#helm_chart-uninstall_opts">uninstall_opts</a>,
-           <a href="#helm_chart-stamp">stamp</a>, <a href="#helm_chart-kwargs">kwargs</a>)
+           <a href="#helm_chart-install_name">install_name</a>, <a href="#helm_chart-registry_url">registry_url</a>, <a href="#helm_chart-helm_opts">helm_opts</a>, <a href="#helm_chart-install_opts">install_opts</a>, <a href="#helm_chart-upgrade_opts">upgrade_opts</a>, <a href="#helm_chart-uninstall_opts">uninstall_opts</a>, <a href="#helm_chart-stamp">stamp</a>,
+           <a href="#helm_chart-kwargs">kwargs</a>)
 </pre>
 
 Rules for producing a helm package and some convenience targets.
@@ -350,7 +350,6 @@ Rules for producing a helm package and some convenience targets.
 | <a id="helm_chart-templates"></a>templates |  A list of template files to include in the package.   |  `None` |
 | <a id="helm_chart-images"></a>images |  A list of [oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags) targets   |  `[]` |
 | <a id="helm_chart-deps"></a>deps |  A list of helm package dependencies.   |  `None` |
-| <a id="helm_chart-tags"></a>tags |  Tags to apply to all targets.   |  `[]` |
 | <a id="helm_chart-install_name"></a>install_name |  The `helm install` name to use. `name` will be used if unset.   |  `None` |
 | <a id="helm_chart-registry_url"></a>registry_url |  The registry url for the helm chart. `{name}.push_registry` is only defined when a value is passed here.   |  `None` |
 | <a id="helm_chart-helm_opts"></a>helm_opts |  Additional options to pass to helm.   |  `[]` |

--- a/helm/private/helm.bzl
+++ b/helm/private/helm.bzl
@@ -14,7 +14,6 @@ def helm_chart(
         templates = None,
         images = [],
         deps = None,
-        tags = [],
         install_name = None,
         registry_url = None,
         helm_opts = [],
@@ -44,7 +43,6 @@ def helm_chart(
         templates (list, optional): A list of template files to include in the package.
         images (list, optional): A list of [oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags) targets
         deps (list, optional): A list of helm package dependencies.
-        tags (list, optional): Tags to apply to all targets.
         install_name (str, optional): The `helm install` name to use. `name` will be used if unset.
         registry_url (str, Optional): The registry url for the helm chart. `{name}.push_registry`
             is only defined when a value is passed here.
@@ -58,9 +56,6 @@ def helm_chart(
     if templates == None:
         templates = native.glob(["templates/**"])
 
-    tags = kwargs.pop("tags", [])
-    tags_with_manual = depset(tags + ["manual"]).to_list()
-
     helm_package(
         name = name,
         chart = chart,
@@ -72,14 +67,12 @@ def helm_chart(
         values_json = values_json,
         substitutions = substitutions,
         stamp = stamp,
-        tags = tags,
         **kwargs
     )
 
     helm_push(
         name = name + ".push",
         package = name,
-        tags = tags_with_manual,
         **kwargs
     )
 
@@ -88,7 +81,6 @@ def helm_chart(
             name = name + ".push_registry",
             package = name,
             registry_url = registry_url,
-            tags = tags_with_manual,
             **kwargs
         )
 
@@ -99,7 +91,6 @@ def helm_chart(
         name = name + ".install",
         install_name = install_name,
         package = name,
-        tags = tags_with_manual,
         helm_opts = helm_opts,
         opts = install_opts,
         **kwargs
@@ -109,7 +100,6 @@ def helm_chart(
         name = name + ".upgrade",
         install_name = install_name,
         package = name,
-        tags = tags_with_manual,
         helm_opts = helm_opts,
         opts = upgrade_opts,
         **kwargs
@@ -118,7 +108,6 @@ def helm_chart(
     helm_uninstall(
         name = name + ".uninstall",
         install_name = install_name,
-        tags = tags_with_manual,
         helm_opts = helm_opts,
         opts = uninstall_opts,
         **kwargs


### PR DESCRIPTION
All targets should be able to build. All of the targets that has `manual` tags will only have side-effects if they're run so there's no risk in building them.

Also, the `tags` were all screwed up because `tags` was an argument and it was being extracted from `**kwargs` so it was impossible to pass in additional `tags`.