### PR TITLE
Add support for crds in the packaged chart

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1448,7 +1448,7 @@
   "moduleExtensions": {
     "//helm:extensions.bzl%helm": {
       "general": {
-        "bzlTransitiveDigest": "T9MUX1sVfUP+QvkBrE9ZH5kyvkk/1WzNU0004l0aOo4=",
+        "bzlTransitiveDigest": "0mnw7j5EJe2CsN3WrtLH8ywoGCCUVwEog64so0GcubY=",
         "accumulatedFileDigests": {},
         "envVariables": {},
         "generatedRepoSpecs": {

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ A rule for performing `helm lint` on a helm package
 ## helm_package
 
 <pre>
-helm_package(<a href="#helm_package-name">name</a>, <a href="#helm_package-deps">deps</a>, <a href="#helm_package-chart">chart</a>, <a href="#helm_package-chart_json">chart_json</a>, <a href="#helm_package-images">images</a>, <a href="#helm_package-stamp">stamp</a>, <a href="#helm_package-substitutions">substitutions</a>, <a href="#helm_package-templates">templates</a>, <a href="#helm_package-values">values</a>,
+helm_package(<a href="#helm_package-name">name</a>, <a href="#helm_package-deps">deps</a>, <a href="#helm_package-chart">chart</a>, <a href="#helm_package-chart_json">chart_json</a>, <a href="#helm_package-crds">crds</a>, <a href="#helm_package-images">images</a>, <a href="#helm_package-stamp">stamp</a>, <a href="#helm_package-substitutions">substitutions</a>, <a href="#helm_package-templates">templates</a>, <a href="#helm_package-values">values</a>,
              <a href="#helm_package-values_json">values_json</a>)
 </pre>
 
@@ -177,6 +177,7 @@ Rules for creating Helm chart packages.
 | <a id="helm_package-deps"></a>deps |  Other helm packages this package depends on.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="helm_package-chart"></a>chart |  The `Chart.yaml` file of the helm chart   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="helm_package-chart_json"></a>chart_json |  The `Chart.yaml` file of the helm chart as a json object   | String | optional |  `""`  |
+| <a id="helm_package-crds"></a>crds | All crds associated with the current helm chart. E.g., the `./crds` directory  | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | `[]` |
 | <a id="helm_package-images"></a>images |  A list of                 [oci_push](https://github.com/bazel-contrib/rules_oci/blob/main/docs/push.md#oci_push_rule-remote_tags)                 targets.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="helm_package-stamp"></a>stamp |  Whether to encode build information into the helm actions. Possible values:<br><br>- `stamp = 1`: Always stamp the build information into the helm actions, even in                 [--nostamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) builds.                 This setting should be avoided, since it potentially kills remote caching for the target and                 any downstream actions that depend on it.<br><br>- `stamp = 0`: Always replace build information by constant values. This gives good build result caching.<br><br>- `stamp = -1`: Embedding of build information is controlled by the                 [--[no]stamp](https://docs.bazel.build/versions/main/user-manual.html#flag--stamp) flag.<br><br>Stamped targets are not rebuilt unless their dependencies change.   | Integer | optional |  `-1`  |
 | <a id="helm_package-substitutions"></a>substitutions |  A dictionary of substitutions to apply to the `values.yaml` file.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |

--- a/helm/private/helm.bzl
+++ b/helm/private/helm.bzl
@@ -61,7 +61,7 @@ def helm_chart(
         templates = native.glob(["templates/**"])
 
     if crds == None:
-        crds = native.glob(["crds/**"], allow_empty=True)
+        crds = native.glob(["crds/**"], allow_empty = True)
 
     helm_package(
         name = name,

--- a/helm/private/helm.bzl
+++ b/helm/private/helm.bzl
@@ -8,6 +8,7 @@ def helm_chart(
         name,
         chart = None,
         chart_json = None,
+        crds = None,
         values = None,
         values_json = None,
         substitutions = {},
@@ -38,6 +39,7 @@ def helm_chart(
         name (str): The name of the [helm_package](#helm_package) target.
         chart (str, optional): The path to the chart directory. Defaults to `Chart.yaml`.
         chart_json (str, optional): The json encoded contents of `Chart.yaml`.
+        crds (list, optional): A list of crd files to include in the package.
         values (str, optional): The path to the values file. Defaults to `values.yaml`.
         values_json (str, optional): The json encoded contents of `values.yaml`.
         substitutions (dict, optional): A dictionary of substitutions to apply to `values.yaml`.
@@ -58,10 +60,14 @@ def helm_chart(
     if templates == None:
         templates = native.glob(["templates/**"])
 
+    if crds == None:
+        crds = native.glob(["crds/**"], allow_empty=True)
+
     helm_package(
         name = name,
         chart = chart,
         chart_json = chart_json,
+        crds = crds,
         deps = deps,
         images = images,
         templates = templates,

--- a/tests/simple/crds/test.crd.yaml
+++ b/tests/simple/crds/test.crd.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must be in the form: <plural>.<group>
+  name: myapps.example.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: example.com
+  scope: Namespaced
+  names:
+    # kind is normally the CamelCased singular type.
+    kind: MyApp
+    # singular name to be used as an alias on the CLI
+    singular: myapp
+    # plural name in the URL: /apis/<group>/<version>/<plural>
+    plural: myapps
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
Solves #84.

The implementation follows the flow of the `templates` folder, but considers that `crds` folder is optional.