### PR TITLE
Update outdated MacOS CI runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-11
+          - os: macos-12
           - os: ubuntu-20.04
           - os: windows-2019
     steps:


### PR DESCRIPTION
To account for https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/