### PR TITLE
Mark test dependencies as dev dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,7 +40,7 @@ register_toolchains(
     "@helm_windows_amd64_toolchain//:toolchain",
 )
 
-helm_test = use_extension("@rules_helm//tests:test_extensions.bzl", "helm_test")
+helm_test = use_extension("@rules_helm//tests:test_extensions.bzl", "helm_test", dev_dependency = True)
 use_repo(
     helm_test,
     "helm_test_deps__with_chart_deps_postgresql",


### PR DESCRIPTION
This was overlooked in #98 and #105 when rules_oci was marked as dev dependency.

Without this change, depending on this module fails as loading the extension fails as evaluating `test_extensions.bzl` fails when loading `test_deps.bzl` which again tries to load from `@rules_oci` which it can't resolve as it is a dev dependency.