### PR TITLE
Allow alternative `push` commands

### DIFF
--- a/helm/private/helm.bzl
+++ b/helm/private/helm.bzl
@@ -20,6 +20,7 @@ def helm_chart(
         install_name = None,
         registry_url = None,
         login_url = None,
+        push_cmd = None,
         helm_opts = [],
         install_opts = [],
         upgrade_opts = [],
@@ -55,6 +56,7 @@ def helm_chart(
         registry_url (str, Optional): The registry url for the helm chart. `{name}.push_registry`
             is only defined when a value is passed here.
         login_url (str, optional): The registry url to log into for publishing helm charts.
+        push_cmd (str, optional): An alternative command to `push` for publishing helm charts.
         helm_opts (list, optional): Additional options to pass to helm.
         install_opts (list, optional): Additional options to pass to `helm install`.
         uninstall_opts (list, optional): Additional options to pass to `helm uninstall`.
@@ -98,6 +100,7 @@ def helm_chart(
             include_images = False,
             registry_url = registry_url,
             login_url = login_url,
+            push_cmd = push_cmd,
             **kwargs
         )
 
@@ -107,6 +110,7 @@ def helm_chart(
             package = name,
             registry_url = registry_url,
             login_url = login_url,
+            push_cmd = push_cmd,
             **kwargs
         )
 

--- a/helm/private/helm_registry.bzl
+++ b/helm/private/helm_registry.bzl
@@ -42,6 +42,9 @@ def _helm_push_impl(ctx):
     if ctx.attr.login_url:
         args.add("-login_url", ctx.attr.login_url)
 
+    if ctx.attr.push_cmd:
+        args.add("-push_cmd", ctx.attr.push_cmd)
+
     image_runfiles = ctx.runfiles()
     if ctx.attr.include_images:
         image_pushers, image_runfiles = _get_image_push_commands(
@@ -105,6 +108,9 @@ if the following environment variables are defined:
             doc = "The helm package to push to the registry.",
             providers = [HelmPackageInfo],
             mandatory = True,
+        ),
+        "push_cmd": attr.string(
+            doc = "An alternative command to `push` for publishing the helm chart. E.g. `cm-push`",
         ),
         "registry_url": attr.string(
             doc = "The registry URL at which to push the helm chart to. E.g. `oci://my.registry.io/chart-name`",

--- a/helm/private/registrar/registrar.go
+++ b/helm/private/registrar/registrar.go
@@ -66,6 +66,7 @@ func main() {
 	rawChartPath := flag.String("chart", "", "Path to Helm .tgz file")
 	registryURL := flag.String("registry_url", "", "URL of registry to upload helm chart")
 	rawLoginURL := flag.String("login_url", "", "URL of registry to login to.")
+	pushCmd := flag.String("push_cmd", "push", "Command to publish helm chart.")
 	rawImagePushers := flag.String("image_pushers", "", "Comma-separated list of image pusher executables")
 
 	// Parse command line arguments
@@ -145,6 +146,6 @@ func main() {
 	}
 
 	// Subprocess helm push
-	log.Println("Running helm push...")
-	runHelm(helmPath, []string{"push", chartPath, *registryURL}, helmPluginsPath, nil)
+	log.Printf("Running helm %s...\n", *pushCmd)
+	runHelm(helmPath, []string{*pushCmd, chartPath, *registryURL}, helmPluginsPath, nil)
 }


### PR DESCRIPTION
Closes #140.

To push chart packages to ChartMuseum registries, one needs to run `helm cm-push` instead of the default `helm push`.

The present change simply consists in adding an optional `push_cmd` string argument to the `helm_chart` macro definition and propagate it down to the registrar.

I've verified the change manually by overriding the `rules_helm` repository using the present branch, but didn't find a simple way to test it yet.