### PR TITLE
Fix architecture name handling for Bazel 8 compatibility

### DIFF
--- a/helm/repositories.bzl
+++ b/helm/repositories.bzl
@@ -148,7 +148,14 @@ def _platform(rctx):
     else:
         fail("unrecognized os")
 
-    return "%s_%s" % (os, rctx.os.arch)
+    # Normalize architecture names
+    arch = rctx.os.arch
+    if arch == "aarch64":
+        arch = "arm64"
+    elif arch == "x86_64":
+        arch = "amd64"
+
+    return "%s_%s" % (os, arch)
 
 def _helm_host_alias_repository_impl(repository_ctx):
     is_windows = repository_ctx.os.name.lower().find("windows") != -1


### PR DESCRIPTION
Bazel 8 reports ARM architectures as "aarch64" while previous versions used "arm64". This causes symlinks to be created incorrectly, pointing to non-existent directories.

This change normalizes architecture names in the _platform function to ensure compatibility with Bazel 8 while maintaining backward compatibility with older versions.

The fix converts "aarch64" to "arm64" and "x86_64" to "amd64" when determining the platform name, ensuring consistent naming regardless of how Bazel reports the architecture.

Fixes issue #145 