### PR TITLE
Update transitive dependencies

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -4,7 +4,8 @@
     {
       "name": "Andre Brisco",
       "email": "91817010+abrisco@users.noreply.github.com",
-      "github": "abrisco"
+      "github": "abrisco",
+      "github_user_id": "91817010"
     }
   ],
   "repository": [

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,43 +19,17 @@ jobs:
       matrix:
         include:
           - os: macos-14
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
           - os: windows-2019
     steps:
       # Checkout the code
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      # Caches and restores the Bazel outputs.
-      - name: Retain Bazel cache (linux)
-        uses: actions/cache@v4
-        env:
-          cache-name: bazel-cache
+      - uses: bazel-contrib/setup-bazel@0.14.0
         with:
-          path: |
-            ~/.cache/bazelisk
-            ~/.cache/bazel
-          key: ${{ runner.os }}-${{ env.cache-name }}
-        if: startswith(runner.os, 'Linux')
-      - name: Retain Bazel cache (MacOS)
-        uses: actions/cache@v4
-        env:
-          cache-name: bazel-cache
-        with:
-          path: |
-            ~/.cache/bazelisk
-            /private/var/tmp/_bazel_runner
-          key: ${{ runner.os }}-${{ env.cache-name }}
-        if: startswith(runner.os, 'MacOS')
-      - name: Retain Bazel cache (Windows)
-        uses: actions/cache@v4
-        env:
-          cache-name: bazel-cache
-        with:
-          path: |
-            ~/.cache/bazelisk
-            C:/bzl
-          key: ${{ runner.os }}-${{ env.cache-name }}
-        if: startswith(runner.os, 'Windows')
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
 
       - name: Setup Bazelrc (Windows)
         run: |
@@ -79,43 +53,17 @@ jobs:
       matrix:
         include:
           - os: macos-14
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
           - os: windows-2019
     steps:
       # Checkout the code
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      # Caches and restores the Bazel outputs.
-      - name: Retain Bazel cache (linux)
-        uses: actions/cache@v4
-        env:
-          cache-name: bazel-cache
+      - uses: bazel-contrib/setup-bazel@0.14.0
         with:
-          path: |
-            ~/.cache/bazelisk
-            ~/.cache/bazel
-          key: ${{ runner.os }}-${{ env.cache-name }}
-        if: startswith(runner.os, 'Linux')
-      - name: Retain Bazel cache (MacOS)
-        uses: actions/cache@v4
-        env:
-          cache-name: bazel-cache
-        with:
-          path: |
-            ~/.cache/bazelisk
-            /private/var/tmp/_bazel_runner
-          key: ${{ runner.os }}-${{ env.cache-name }}
-        if: startswith(runner.os, 'MacOS')
-      - name: Retain Bazel cache (Windows)
-        uses: actions/cache@v4
-        env:
-          cache-name: bazel-cache
-        with:
-          path: |
-            ~/.cache/bazelisk
-            C:/bzl
-          key: ${{ runner.os }}-${{ env.cache-name }}
-        if: startswith(runner.os, 'Windows')
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
 
       - name: Setup Bazelrc (Windows)
         run: |
@@ -138,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout the code
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Buildifier
         run: |
           wget "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDIFIER_VERSION}/buildifier-linux-amd64" -O buildifier
@@ -151,7 +99,7 @@ jobs:
   ci-gofmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: Jerome1337/gofmt-action@v1.0.5
         with:
           gofmt-flags: -e -d

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       attestations: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: main
       - name: Detect the current version

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,15 +9,15 @@ module(
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "gazelle", version = "0.36.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "gazelle", version = "0.43.0", repo_name = "bazel_gazelle")
 
 # `aspect_bazel_lib` is unfortunately required by `rules_oci`.
 # https://github.com/bazel-contrib/rules_oci/issues/575
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.2", dev_dependency = True)
-bazel_dep(name = "rules_oci", version = "2.0.0", dev_dependency = True)
-bazel_dep(name = "stardoc", version = "0.7.1", dev_dependency = True, repo_name = "io_bazel_stardoc")
-bazel_dep(name = "rules_rust_mdbook", version = "0.57.0", dev_dependency = True)
-bazel_dep(name = "rules_shell", version = "0.3.0", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.14.0", dev_dependency = True)
+bazel_dep(name = "rules_oci", version = "2.2.5", dev_dependency = True)
+bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True, repo_name = "io_bazel_stardoc")
+bazel_dep(name = "rules_rust_mdbook", version = "0.60.0", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.23.0")

--- a/helm/private/versions.bzl
+++ b/helm/private/versions.bzl
@@ -1,6 +1,6 @@
 """Constants for accessing helm binaries"""
 
-DEFAULT_HELM_VERSION = "3.17.1"
+DEFAULT_HELM_VERSION = "3.17.3"
 
 DEFAULT_HELM_URL_TEMPLATES = [
     "https://get.helm.sh/helm-v{version}-{platform}.{compression}",
@@ -20,7 +20,7 @@ CONSTRAINTS = {
 # This list is manually updated using the following command to get the
 # integrity values for each artifact:
 # ```
-# bazel query 'set(@helm_darwin_amd64//... @helm_darwin_arm64//... @helm_linux_amd64//... @helm_linux_arm//... @helm_linux_arm64//... @helm_linux_i386//... @helm_linux_ppc64le//... @helm_windows_amd64//...)' 2>&1 | grep integrity
+# bazel run //tools/fetch_shas -- <version>
 # ```
 HELM_VERSIONS = {
     "2.17.0": {
@@ -345,6 +345,26 @@ HELM_VERSIONS = {
         "linux-i386": "sha256-uXJWKhFxZz2yiS8AAkiyVA3c1vdoUOwVKFKo6c55css=",
         "linux-ppc64le": "sha256-QiM5Tz/Kgqf46NCDyvb68O4GOdjyNQcTNFeSNweKLC4=",
         "windows-amd64": "sha256-CCge5tTScoNf8QxRC4s5c20RLZy4nfvIU/6DkT++SNA=",
+    },
+    "3.17.2": {
+        "darwin-amd64": "sha256-PiQCOMejoQ79N7jhZhWyjpS6XbWVcke7QgCbptUvduk=",
+        "darwin-arm64": "sha256-uEPOvL68nsyx5Dq6nMp2k9MunyxKNTRJkOO3s4GTOUg=",
+        "linux-amd64": "sha256-kMKHkqHrX7C1ACjjnr+CZTHr/Pc/WZBQ29ebqy8nckE=",
+        "linux-arm": "sha256-CxPshYDdVJi1otfLNBRuCYBJ9ZUAombbG7mPWWSeuQo=",
+        "linux-arm64": "sha256-14127HYlqUmR6IesBJ2T9EvXDkh2IAuUX4E8nh7R33w=",
+        "linux-i386": "sha256-HFmcRVm5fYzyEAcE9c3DJp3LNptVNxGwmlZOHYnHJdw=",
+        "linux-ppc64le": "sha256-a7HIMHi91emsrVeT38mrO1tW1BByOmYP8dph29/zIHs=",
+        "windows-amd64": "sha256-92/nb6EW0rrpSK7pu1S6Eb9bcmoJ9zLOanTrZa8ohrE=",
+    },
+    "3.17.3": {
+        "darwin-amd64": "sha256-IO+N9GcTSab8VWpiG+EXDdcJxsDPX36Dotn7BRX9l/w=",
+        "darwin-arm64": "sha256-ia7EPOB7BiOfG7pKZQcja7SK5Ie8UGWo4lTTzlihaZc=",
+        "linux-amd64": "sha256-7oizyFGuZGaj3lB/e+c/6U1Uy/KYfLqj0aODLqMx8s0=",
+        "linux-arm": "sha256-YNdtHhLT4Fip6aggnv90im+rWUgCih8IYPSOFBJD0z0=",
+        "linux-arm64": "sha256-eUTj3v04bHb9ktnm/sXC1loyP2+twZv7XnBOPu4QNI4=",
+        "linux-i386": "sha256-UXQteMBmQ34js8qYNw3zQfkTa0CDgf5aFQ1wudm/JNc=",
+        "linux-ppc64le": "sha256-uCGIWlArL6FZ4+86/pzebmyYdtSmI/GIaIKcPuSjxkw=",
+        "windows-amd64": "sha256-jqk+L2KF5kne3lg6yQ/4zbk4ylPsbPX+kJ8jA/vCLZY=",
     },
     "3.4.2": {
         "darwin-amd64": "sha256-wzt+5ysABvI7M/UDK1Md1gn/97CKQyT5ugdyKk8/7Jo=",


### PR DESCRIPTION
Bumped various bzlmod deps and updated ubuntu runner above `ubuntu-20.04` to avoid Github deprecation.