### PR TITLE
Update setup directions for using MODULE.bazel

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,32 +4,12 @@ Bazel rules for producing [helm charts][helm]
 
 [helm]: https://helm.sh/
 
-## Setup WORKSPACE
+## Setup MODULE.bazel
 
-```python
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+`rules_helm` is published to the
+[Bazel Central Registry](https://registry.bazel.build/modules/rules_helm):
 
-# See releases for urls and checksums
-http_archive(
-    name = "rules_helm",
-    sha256 = "{sha256}",
-    urls = ["https://github.com/abrisco/rules_helm/releases/download/{version}/rules_helm-v{version}.tar.gz"],
-)
-
-load("@rules_helm//helm:repositories.bzl", "helm_register_toolchains", "rules_helm_dependencies")
-
-rules_helm_dependencies()
-
-helm_register_toolchains()
-
-load("@rules_helm//helm:repositories_transitive.bzl", "rules_helm_transitive_dependencies")
-
-rules_helm_transitive_dependencies()
-```
-
-## Setup MODULE
-
-```python
+```starlark
 bazel_dep(name = "rules_helm", version = "{version}")
 ```
 


### PR DESCRIPTION
Bzlmod is replacing `WORKSPACE` in Bazel 8 and will be removed from Bazel 9:
https://bazel.build/external/migration#define-root