### PR TITLE
Add `helm_template` rule to write the output from `helm template` to a file

### DIFF
--- a/helm/defs.bzl
+++ b/helm/defs.bzl
@@ -36,6 +36,7 @@ load(
 )
 load(
     "//helm/private:helm_template.bzl",
+    _helm_template = "helm_template",
     _helm_template_test = "helm_template_test",
 )
 load(
@@ -65,6 +66,7 @@ helm_push = _helm_push
 helm_push_images = _helm_push_images
 helm_push_registry = _helm_push
 helm_register_toolchains = _helm_register_toolchains
+helm_template = _helm_template
 helm_template_test = _helm_template_test
 helm_toolchain = _helm_toolchain
 helm_uninstall = _helm_uninstall

--- a/helm/private/helm_template.bzl
+++ b/helm/private/helm_template.bzl
@@ -130,7 +130,7 @@ def _helm_template_impl(ctx):
 
     chart_info = ctx.attr.chart[HelmPackageInfo]
 
-    output = ctx.actions.declare_file(ctx.label.name + ".yaml")
+    output = ctx.outputs.out if ctx.outputs.out else ctx.actions.declare_file(ctx.label.name + ".yaml")
 
     args = ctx.actions.args()
     args.add("-helm", toolchain.helm)
@@ -161,6 +161,9 @@ helm_template = rule(
             doc = "The helm package to resolve charts for.",
             mandatory = True,
             providers = [HelmPackageInfo],
+        ),
+        "out": attr.output(
+            doc = "The output file to write the output from `helm template`.",
         ),
         "_templater": attr.label(
             doc = "A process wrapper to use for running `helm template`.",

--- a/helm/private/helm_template.bzl
+++ b/helm/private/helm_template.bzl
@@ -142,7 +142,7 @@ def _helm_template_impl(ctx):
         executable = ctx.executable._templater,
         outputs = [output],
         inputs = depset([chart_info.chart]),
-        tools = depset([toolchain.helm]),
+        tools = depset([toolchain.helm, toolchain.helm_plugins]),
         mnemonic = "HelmTemplate",
         arguments = [args],
         progress_message = "Running Helm Template for {}".format(ctx.label),

--- a/helm/private/templater/BUILD.bazel
+++ b/helm/private/templater/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+
+go_binary(
+    name = "templater",
+    srcs = ["templater.go"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//helm/private/helm_utils",
+        "@in_gopkg_yaml_v3//:yaml_v3",
+    ],
+)

--- a/helm/private/templater/BUILD.bazel
+++ b/helm/private/templater/BUILD.bazel
@@ -6,6 +6,5 @@ go_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//helm/private/helm_utils",
-        "@in_gopkg_yaml_v3//:yaml_v3",
     ],
 )

--- a/helm/private/templater/templater.go
+++ b/helm/private/templater/templater.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"github.com/abrisco/rules_helm/helm/private/helm_utils"
+)
+
+type Arguments struct {
+	helm        string
+	helmPlugins string
+	chart       string
+	output      string
+}
+
+func makeAbsolutePath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal("Couldn't determine current working directory")
+	}
+	return filepath.Join(cwd, path)
+}
+
+func parse_args() Arguments {
+	var args Arguments
+
+	flag.StringVar(&args.helm, "helm", "", "The path to a helm executable")
+	flag.StringVar(&args.helmPlugins, "helm_plugins", "", "The path to a helm plugins directory")
+	flag.StringVar(&args.chart, "chart", "", "The path to the helm chart to template.")
+	flag.StringVar(&args.output, "output", "", "The output file to write.")
+	flag.Parse()
+
+	return args
+}
+
+func main() {
+	args := parse_args()
+
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	chart := makeAbsolutePath(args.chart)
+	helm := makeAbsolutePath(args.helm)
+	helmPlugins := makeAbsolutePath(args.helmPlugins)
+	output := makeAbsolutePath(args.output)
+
+	helmArgs := []string{"template", chart}
+	cmd, err := helm_utils.BuildHelmCommand(helm, helmArgs, helmPlugins)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	exitCode := 0
+	var cmdError error
+
+	cmdErr := cmd.Run()
+	if cmdErr != nil {
+		if exitError, ok := cmdErr.(*exec.ExitError); ok {
+			if status, ok := exitError.Sys().(syscall.WaitStatus); ok {
+				exitCode = status.ExitStatus()
+			}
+		} else {
+			cmdError = cmdErr
+			exitCode = 1
+		}
+	}
+
+	if cmdError != nil {
+		os.Stderr.Write(stderr.Bytes())
+		log.Fatal(cmdError)
+	}
+
+	err = os.WriteFile(output, stdout.Bytes(), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Exit(exitCode)
+}

--- a/helm/private/templater/templater.go
+++ b/helm/private/templater/templater.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"log"
 	"os"
@@ -58,11 +57,13 @@ func main() {
 		log.Fatal(err)
 	}
 
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
+	outputFile, err := os.Create(output)
+	if err != nil {
+		log.Fatal(err)
+	}
 
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	cmd.Stdout = outputFile
+	cmd.Stderr = os.Stderr
 
 	exitCode := 0
 	var cmdError error
@@ -80,13 +81,7 @@ func main() {
 	}
 
 	if cmdError != nil {
-		os.Stderr.Write(stderr.Bytes())
 		log.Fatal(cmdError)
-	}
-
-	err = os.WriteFile(output, stdout.Bytes(), 0644)
-	if err != nil {
-		log.Fatal(err)
 	}
 
 	os.Exit(exitCode)

--- a/tests/no_templates/BUILD.bazel
+++ b/tests/no_templates/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_template_test")
+load("//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_template", "helm_template_test")
 
 helm_chart(
     name = "no_templates",
@@ -8,6 +8,11 @@ helm_chart(
 
 helm_lint_test(
     name = "no_templates_lint_test",
+    chart = ":no_templates",
+)
+
+helm_template(
+    name = "no_templates_template",
     chart = ":no_templates",
 )
 

--- a/tests/simple/BUILD.bazel
+++ b/tests/simple/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_template_test")
+load("//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_template", "helm_template_test")
 
 helm_chart(
     name = "simple",
@@ -7,6 +7,11 @@ helm_chart(
 
 helm_lint_test(
     name = "simple_lint_test",
+    chart = ":simple",
+)
+
+helm_template(
+    name = "simple_template",
     chart = ":simple",
 )
 

--- a/tests/simple/BUILD.bazel
+++ b/tests/simple/BUILD.bazel
@@ -12,6 +12,7 @@ helm_lint_test(
 
 helm_template(
     name = "simple_template",
+    out = "simple.yaml",
     chart = ":simple",
 )
 


### PR DESCRIPTION
I wasn't able to reuse https://github.com/abrisco/rules_helm/blob/main/helm/private/runner/runner.go since that only seems to be useful as a binary target in `bazel run` and not to write an output file instead.

Support for passing values files to `helm template` will also be added.