### PR TITLE
Update `helm_import_repository` to support only specifying URL

### DIFF
--- a/helm/private/helm_import.bzl
+++ b/helm/private/helm_import.bzl
@@ -117,20 +117,19 @@ def _helm_import_repository_impl(repository_ctx):
 
 helm_import_repository = repository_rule(
     implementation = _helm_import_repository_impl,
-    doc = "A rule for fetching external Helm charts from an arbitrary repository.",
+    doc = "A rule for fetching external Helm charts from an arbitrary URL or repository.",
     attrs = {
         "chart_name": attr.string(
             doc = "Chart name to import.",
         ),
         "repository": attr.string(
             doc = "Chart repository url where to locate the requested chart.",
-            mandatory = True,
         ),
         "sha256": attr.string(
             doc = "The expected SHA-256 hash of the chart imported.",
         ),
         "url": attr.string(
-            doc = "The url where the chart can be directly downloaded.",
+            doc = "The url where the chart can be directly downloaded. Takes precendence over `repository`",
         ),
         "version": attr.string(
             doc = "Specify a version constraint for the chart version to use.",

--- a/helm/private/helm_import.bzl
+++ b/helm/private/helm_import.bzl
@@ -98,6 +98,9 @@ def _helm_import_repository_impl(repository_ctx):
 
         chart_url = _find_chart_url(repository_ctx, repo_yaml, file_name)
 
+    if not chart_url.startswith("http"):
+        fail("Cannot download from {}, unsupported protocol".format(chart_url))
+
     # Parse the chart file name from the URL
     _, _, chart_file = chart_url.rpartition("/")
     chart_name, _, chart_version = chart_file.removesuffix(".tgz").rpartition("-")

--- a/tests/test_deps.bzl
+++ b/tests/test_deps.bzl
@@ -21,9 +21,7 @@ def helm_test_deps():
     maybe(
         helm_import_repository,
         name = "helm_test_deps__with_chart_deps_redis",
-        repository = "https://charts.bitnami.com/bitnami",
         url = "https://charts.bitnami.com/bitnami/redis-14.4.0.tgz",
-        version = "14.4.0",
         sha256 = "43374837646a67539eb2999cd8973dc54e8fcdc14896761e594b9d616734edf2",
         chart_name = "redis",
     )
@@ -31,9 +29,7 @@ def helm_test_deps():
     maybe(
         helm_import_repository,
         name = "helm_test_deps__with_chart_deps_postgresql",
-        repository = "https://charts.bitnami.com/bitnami",
         url = "https://charts.bitnami.com/bitnami/postgresql-14.0.5.tgz",
-        version = "14.0.5",
         sha256 = "38d9b6657aa3b0cc16d190570dbaf96796e997d03a1665264dac9966343e4d1b",
         chart_name = "postgresql",
     )

--- a/tests/test_deps.bzl
+++ b/tests/test_deps.bzl
@@ -23,7 +23,6 @@ def helm_test_deps():
         name = "helm_test_deps__with_chart_deps_redis",
         url = "https://charts.bitnami.com/bitnami/redis-14.4.0.tgz",
         sha256 = "43374837646a67539eb2999cd8973dc54e8fcdc14896761e594b9d616734edf2",
-        chart_name = "redis",
     )
 
     maybe(
@@ -31,7 +30,6 @@ def helm_test_deps():
         name = "helm_test_deps__with_chart_deps_postgresql",
         url = "https://charts.bitnami.com/bitnami/postgresql-14.0.5.tgz",
         sha256 = "38d9b6657aa3b0cc16d190570dbaf96796e997d03a1665264dac9966343e4d1b",
-        chart_name = "postgresql",
     )
 
     maybe(


### PR DESCRIPTION
Download the chart specified by `url`, assuming the URL is a valid chart file name to determine the name and version.

This PR also makes the `url` attribute exclusive with `chart_name`, `repository`, and `version`.