### PR TITLE
Only include `.yaml` files in `crds`

### DIFF
--- a/helm/private/helm.bzl
+++ b/helm/private/helm.bzl
@@ -75,7 +75,7 @@ def helm_chart(
         templates = native.glob(["templates/**"])
 
     if crds == None:
-        crds = native.glob(["crds/**"], allow_empty = True)
+        crds = native.glob(["crds/**/*.yaml"], allow_empty = True)
 
     helm_package(
         name = name,

--- a/helm/private/helm_package.bzl
+++ b/helm/private/helm_package.bzl
@@ -243,7 +243,7 @@ helm_package = rule(
                 "associated with the current helm chart. E.g., the `./crds` directory"
             ),
             default = [],
-            allow_files = True,
+            allow_files = [".yaml"],
         ),
         "deps": attr.label_list(
             doc = "Other helm packages this package depends on.",


### PR DESCRIPTION
CRDs are stored as YAML: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/

Interestingly, `helm lint` doesn't check files in the `crds/` directory unlike `templates/`.

Bazel documentation also recommends glob matches specific extensions instead of bare patterns: https://bazel.build/reference/be/functions#glob