### PR TITLE
Remove deprecated parameter

### DIFF
--- a/helm/private/current_toolchain.bzl
+++ b/helm/private/current_toolchain.bzl
@@ -21,6 +21,5 @@ def _current_helm_toolchain_impl(ctx):
 current_helm_toolchain = rule(
     implementation = _current_helm_toolchain_impl,
     toolchains = ["@rules_helm//helm:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
     doc = DOC,
 )


### PR DESCRIPTION
The parameter `incompatible_use_toolchain_transition` has no effect since Bazel 6, and is incompatible with the (yet to be released) Bazel 9.