### PR TITLE
fix: aspect_bazel_lib is no longer just a dev dep

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,10 +10,8 @@ bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.1")
 bazel_dep(name = "rules_go", version = "0.56.1", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "gazelle", version = "0.45.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "aspect_bazel_lib", version = "2.20.0")
 
-# `aspect_bazel_lib` is unfortunately required by `rules_oci`.
-# https://github.com/bazel-contrib/rules_oci/issues/575
-bazel_dep(name = "aspect_bazel_lib", version = "2.20.0", dev_dependency = True)
 bazel_dep(name = "rules_oci", version = "2.2.6", dev_dependency = True)
 bazel_dep(name = "rules_img", version = "0.2.6", dev_dependency = True)
 bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True, repo_name = "io_bazel_stardoc")


### PR DESCRIPTION
`aspect_bazel_lib` is used by https://github.com/abrisco/rules_helm/blob/317952e72348b172ad7efb11d74da9b6e374f348/helm/private/helm_import_authn.bzl#L3-L4 so it is no longer a dev dep.

When upgrading to the latest release, we saw this error:
```
at .../external/rules_helm+/helm/defs.bzl:13:5: at .../external/rules_helm+/helm/private/helm_import.bzl:4:6: at .../external/rules_helm+/helm/private/helm_import_authn.bzl:3:6: Unable to find package for @@[unknown repo 'aspect_bazel_lib' requested from @@rules_helm+]//lib:base64.bzl: The repository '@@[unknown repo 'aspect_bazel_lib' requested from @@rules_helm+]' could not be resolved: No repository visible as '@aspect_bazel_lib' from repository '@@rules_helm+'.
```