### PR TITLE
Correctly forward runfiles environment

### DIFF
--- a/helm/private/registrar/registrar.go
+++ b/helm/private/registrar/registrar.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/abrisco/rules_helm/helm/private/helm_utils"
+	"github.com/bazelbuild/rules_go/go/runfiles"
 )
 
 // Chart represents the structure of Chart.yaml
@@ -133,11 +134,17 @@ func main() {
 		log.Printf("WARNING: A Helm registry password was set but no associated `HELM_REGISTRY_USERNAME` var was found. Skipping `helm registry login`.")
 	}
 
+	r, err := runfiles.New()
+	if err != nil {
+		log.Fatalf("Unable to create runfiles.")
+	}
+
 	// Subprocess image pushers
 	for _, pusher := range imagePushers {
 		cmd := exec.Command(pusher)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		cmd.Env = r.Env()
 
 		log.Printf("Running image pusher: %s", pusher)
 		if err := cmd.Run(); err != nil {


### PR DESCRIPTION
This fixes the following error:
```
Running image pusher: HOME/.cache/bazel/_bazel_USER/5a20045a6aeb41ebf8539fa0c86019f2/execroot/_main/bazel-out/haswell-fastbuild/bin/cloud/coturn/push_turn_credentials_provider_image_push.sh
ERROR: runfiles.bash initializer cannot find bazel_tools/tools/bash/runfiles/runfiles.bash. An executable rule may have forgotten to expose it in the runfiles, or the binary may require RUNFILES_DIR to be set.
```

This error is happening since `rules_oci` v2.2.7 (specifically https://github.com/bazel-contrib/rules_oci/commit/e2d375d08df043e5125ef68a8ba5b01d4292dc05).

We are already declaring the runfiles correctly in https://github.com/abrisco/rules_helm/blob/ec0acf952bf63f946173f6672fe069fa6d11613e/helm/private/helm_registry.bzl#L6-L16 but in order to determine the correct runfiles root, those environment variables need to be forwarded correctly.