### PR TITLE
Make `helm_template_test` report all the errors before failing.

### DIFF
--- a/helm/private/runner/runner.go
+++ b/helm/private/runner/runner.go
@@ -203,22 +203,33 @@ func main() {
 			}
 
 			templates := parseHelmOutput(test_stream.String())
+			failed := false
 			for templatePath, testPatterns := range patterns {
 				content, found := templates[templatePath]
 				if !found {
-					log.Fatalf("Template not found in the helm chart: %s", templatePath)
+					failed = true
+					log.Printf("Template not found in the helm chart: %s", templatePath)
+					continue
 				}
 
 				for _, pattern := range testPatterns {
 					regex, err := regexp.Compile(pattern)
 					if err != nil {
-						log.Fatal("Error compiling regex:", err)
+						failed = true
+						log.Print("Error compiling regex:", err)
+						continue
 					}
 
 					if !regex.MatchString(content) {
-						log.Fatalf("Error: The file `%s` does not contain the pattern:\n```\n%s\n```", templatePath, pattern)
+						failed = true
+						log.Printf("Error: The file `%s` does not contain the pattern:\n```\n%s\n```", templatePath, pattern)
+						continue
 					}
 				}
+			}
+
+			if failed {
+				log.Fatalf("Failed")
 			}
 		}
 	}


### PR DESCRIPTION
# Description

Address https://github.com/abrisco/rules_helm/issues/227 by processing all the test pattern and only invoking `log.Fatal` at the end if there was an error.

## Testing

I hacked in some extra (failing) test cases on an existing test case. I didn't find any unit test test that check that failure modes for `helm_template_test` so I didn't bother including my test cases in this PR.