### PR TITLE
fix passing environment variables to image pushers

### DIFF
--- a/helm/private/registrar/registrar.go
+++ b/helm/private/registrar/registrar.go
@@ -144,7 +144,7 @@ func main() {
 		cmd := exec.Command(pusher)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		cmd.Env = r.Env()
+		cmd.Env = append(os.Environ(), r.Env()...)
 
 		log.Printf("Running image pusher: %s", pusher)
 		if err := cmd.Run(); err != nil {


### PR DESCRIPTION
This PR fixes passing environment variables to image pushers.
Currently in `registrar.go` the current Env is lost, it is replaced by env from runfiles module instead of appending it.