### PR TITLE
Allow registry URL to be specified from a file

### DIFF
--- a/helm/private/helm.bzl
+++ b/helm/private/helm.bzl
@@ -20,6 +20,7 @@ def helm_chart(
         deps = None,
         install_name = None,
         registry_url = None,
+        registry_url_file = None,
         login_url = None,
         push_cmd = None,
         helm_opts = [],
@@ -58,7 +59,9 @@ def helm_chart(
         deps (list, optional): A list of helm package dependencies.
         install_name (str, optional): The `helm install` name to use. `name` will be used if unset.
         registry_url (str, Optional): The registry url for the helm chart. `{name}.push_registry`
-            is only defined when a value is passed here.
+            is defined when a value is passed here.
+        registry_url_file (str, Optional): Label of a file containing the registry url for the helm chart. `{name}.push_registry`
+            is defined when a value is passed here.
         login_url (str, optional): The registry url to log into for publishing helm charts.
         push_cmd (str, optional): An alternative command to `push` for publishing helm charts.
         helm_opts (list, optional): Additional options to pass to helm.
@@ -120,12 +123,17 @@ def helm_chart(
         **kwargs
     )
 
-    if registry_url:
+    registry_url_file_label = None
+    if registry_url_file:
+        registry_url_file_label = Label(registry_url_file)
+
+    if registry_url or registry_url_file_label:
         helm_push(
             name = name + ".push_registry",
             package = name,
             include_images = False,
             registry_url = registry_url,
+            registry_url_file = registry_url_file_label,
             login_url = login_url,
             opts = helm_opts + push_opts,
             push_cmd = push_cmd,
@@ -137,6 +145,7 @@ def helm_chart(
             include_images = True,
             package = name,
             registry_url = registry_url,
+            registry_url_file = registry_url_file_label,
             login_url = login_url,
             opts = helm_opts + push_opts,
             push_cmd = push_cmd,

--- a/helm/private/registrar/registrar.go
+++ b/helm/private/registrar/registrar.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"os"
@@ -67,6 +68,7 @@ func main() {
 	rawHelmPluginsPath := flag.String("helm_plugins", "", "The path to helm plugins.")
 	rawChartPath := flag.String("chart", "", "Path to Helm .tgz file")
 	registryURL := flag.String("registry_url", "", "URL of registry to upload helm chart")
+	registryURLFile := flag.String("registry_url_file", "", "Path of the file containing the registry URL of where to upload the chart")
 	rawLoginURL := flag.String("login_url", "", "URL of registry to login to.")
 	pushCmd := flag.String("push_cmd", "push", "Command to publish helm chart.")
 	rawImagePushers := flag.String("image_pushers", "", "Comma-separated list of image pusher executables")
@@ -76,8 +78,28 @@ func main() {
 	helmArgs := flag.CommandLine.Args()
 
 	// Check required arguments
-	if *rawHelmPath == "" || *rawChartPath == "" || *registryURL == "" {
-		log.Fatalf("Missing required arguments: helm, chart, registry_url")
+	if *rawHelmPath == "" || *rawChartPath == "" {
+		log.Fatalf("Missing required arguments: helm, chart")
+	}
+
+	var pushRegistryURL string
+	if *registryURL != "" {
+		pushRegistryURL = *registryURL
+	} else if *registryURLFile != "" {
+		path := helm_utils.GetRunfile(*registryURLFile)
+		r, err := os.Open(path)
+		if err != nil {
+			log.Fatalf("Failed to open registry url file: %v\n", err)
+		}
+
+		defer r.Close()
+		if data, err := io.ReadAll(r); err == nil {
+			pushRegistryURL = string(data)
+		} else {
+			log.Fatalf("Failed to read registry url file: %v\n", err)
+		}
+	} else {
+		log.Fatalf("Missing required arguments: either registry_url or registry_url_file needs to be set")
 	}
 
 	helmPath := helm_utils.GetRunfile(*rawHelmPath)
@@ -120,9 +142,9 @@ func main() {
 	if helmUser != "" && helmPassword != "" {
 		loginUrl := *rawLoginURL
 
-		// If an explicit login url was not set, attempt to parse it from registryURL.
+		// If an explicit login url was not set, attempt to parse it from pushRegistryURL.
 		if loginUrl == "" {
-			host, err := getHostFromURL(*registryURL)
+			host, err := getHostFromURL(pushRegistryURL)
 			if err == nil {
 				loginUrl = host
 			}
@@ -156,5 +178,5 @@ func main() {
 
 	// Subprocess helm push
 	log.Printf("Running helm %s...\n", *pushCmd)
-	runHelm(helmPath, append([]string{*pushCmd, chartPath, *registryURL}, helmArgs...), helmPluginsPath, nil)
+	runHelm(helmPath, append([]string{*pushCmd, chartPath, pushRegistryURL}, helmArgs...), helmPluginsPath, nil)
 }

--- a/helm/private/registry.bzl
+++ b/helm/private/registry.bzl
@@ -37,7 +37,15 @@ def _helm_push_impl(ctx):
     args.add("-helm", rlocationpath(toolchain.helm, ctx.workspace_name))
     args.add("-helm_plugins", rlocationpath(toolchain.helm_plugins, ctx.workspace_name))
     args.add("-chart", rlocationpath(pkg_info.chart, ctx.workspace_name))
-    args.add("-registry_url", ctx.attr.registry_url)
+
+    registry_runfiles = ctx.runfiles()
+    if hasattr(ctx.attr, "registry_url") and ctx.attr.registry_url:
+        args.add("-registry_url", ctx.attr.registry_url)
+    elif hasattr(ctx.attr, "registry_url_file") and ctx.attr.registry_url_file:
+        args.add("-registry_url_file", rlocationpath(ctx.file.registry_url_file, ctx.workspace_name))
+        registry_runfiles = ctx.runfiles(files = [ctx.file.registry_url_file])
+    else:
+        fail("Either `registry_url` or `registry_url_file` must be set for helm_push target")
 
     if ctx.attr.login_url:
         args.add("-login_url", ctx.attr.login_url)
@@ -71,7 +79,7 @@ def _helm_push_impl(ctx):
         toolchain.helm,
         toolchain.helm_plugins,
         pkg_info.chart,
-    ]).merge(image_runfiles)
+    ]).merge(image_runfiles).merge(registry_runfiles)
 
     return [
         DefaultInfo(
@@ -120,8 +128,11 @@ if the following environment variables are defined:
             doc = "An alternative command to `push` for publishing the helm chart. E.g. `cm-push`",
         ),
         "registry_url": attr.string(
-            doc = "The registry URL at which to push the helm chart to. E.g. `oci://my.registry.io/chart-name`",
-            mandatory = True,
+            doc = "The registry URL at which to push the helm chart to. E.g. `oci://my.registry.io/chart-name`. Either this or `registry_url_file` needs to be set. If both are set, this setting takes precedence.",
+        ),
+        "registry_url_file": attr.label(
+            doc = "A file containing the registry URL to push the Helm chart to. E.g. `oci://my.registry.io/chart-name`. Either this or `registry_url` needs to be set.",
+            allow_single_file = True,
         ),
         "_copier": attr.label(
             cfg = "exec",


### PR DESCRIPTION
Adds a new registry_url_file parameter to the helm_push rule, as an alternative to the registry_url parameter.

This allows for the registry URL to be dynamically determined based on stamping / build flags / other means, with a generated file.