### PR TITLE
runner: forward wrapper's runfiles env to spawned image pushers

### DIFF
--- a/helm/private/runner/BUILD.bazel
+++ b/helm/private/runner/BUILD.bazel
@@ -6,5 +6,6 @@ go_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//helm/private/helm_utils",
+        "@rules_go//go/runfiles",
     ],
 )

--- a/helm/private/runner/runner.go
+++ b/helm/private/runner/runner.go
@@ -141,12 +141,26 @@ func main() {
 		}
 	}
 
-	// Subprocess image pushers
-	if !is_test {
+	// Subprocess image pushers.
+	//
+	// Forward the wrapper's runfiles env to each pusher.
+	if !is_test && len(imagePushers) > 0 {
+		runfilesEnv := []string{}
+		if d := os.Getenv("RUNFILES_DIR"); d != "" {
+			runfilesEnv = append(runfilesEnv, "RUNFILES_DIR="+d)
+		}
+		if m := os.Getenv("RUNFILES_MANIFEST_FILE"); m != "" {
+			runfilesEnv = append(runfilesEnv, "RUNFILES_MANIFEST_FILE="+m)
+		}
+		if len(runfilesEnv) == 0 {
+			// Fallback for callers that didn't set the env vars.
+			runfilesEnv = append(runfilesEnv, "RUNFILES_DIR="+os.Args[0]+".runfiles")
+		}
 		for _, pusher := range imagePushers {
 			cmd := exec.Command(pusher)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
+			cmd.Env = append(os.Environ(), runfilesEnv...)
 
 			if err := cmd.Run(); err != nil {
 				log.Fatalf("Failed to run image pusher %s: %v", pusher, err)

--- a/helm/private/runner/runner.go
+++ b/helm/private/runner/runner.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/bazelbuild/rules_go/go/runfiles"
 	"github.com/periareon/rules_helm/helm/private/helm_utils"
 )
 
@@ -142,25 +143,16 @@ func main() {
 	}
 
 	// Subprocess image pushers.
-	//
-	// Forward the wrapper's runfiles env to each pusher.
 	if !is_test && len(imagePushers) > 0 {
-		runfilesEnv := []string{}
-		if d := os.Getenv("RUNFILES_DIR"); d != "" {
-			runfilesEnv = append(runfilesEnv, "RUNFILES_DIR="+d)
-		}
-		if m := os.Getenv("RUNFILES_MANIFEST_FILE"); m != "" {
-			runfilesEnv = append(runfilesEnv, "RUNFILES_MANIFEST_FILE="+m)
-		}
-		if len(runfilesEnv) == 0 {
-			// Fallback for callers that didn't set the env vars.
-			runfilesEnv = append(runfilesEnv, "RUNFILES_DIR="+os.Args[0]+".runfiles")
+		r, err := runfiles.New()
+		if err != nil {
+			log.Fatalf("Failed to load runfiles: %v", err)
 		}
 		for _, pusher := range imagePushers {
 			cmd := exec.Command(pusher)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
-			cmd.Env = append(os.Environ(), runfilesEnv...)
+			cmd.Env = append(os.Environ(), r.Env()...)
 
 			if err := cmd.Run(); err != nil {
 				log.Fatalf("Failed to run image pusher %s: %v", pusher, err)


### PR DESCRIPTION
We invoke the helm install wrapper from a separate Bazel action (not via `bazel run`), and in that path the inherited environment doesn't include `RUNFILES_DIR`. Each spawned image pusher then falls back to discovering runfiles from its own location.

That can land it on a per-pusher manifest that disagrees with the substituted `rlocation` keys , causing `rlocation` to return empty and bash to exit 127.

closes https://github.com/periareon/rules_helm/issues/257