### PR TITLE
Add helm_plugin support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -53,6 +53,29 @@ register_toolchains(
     "@helm_toolchains//:all",
 )
 
+# Test-only: exercise the `helm.plugin` extension by wiring helm-cm-push into all
+# generated toolchains. Consumed by `//tests/bzlmod_plugin`. dev_dependency keeps
+# this out of downstream builds.
+helm_dev = use_extension(
+    "@rules_helm//helm:extensions.bzl",
+    "helm",
+    dev_dependency = True,
+)
+helm_dev.plugin(
+    name = "cm-push",
+    version = "0.10.4",
+    url_templates = {
+        "linux-amd64": ["https://github.com/chartmuseum/helm-push/releases/download/v{version}/helm-push_{version}_linux_amd64.tar.gz"],
+        "darwin-arm64": ["https://github.com/chartmuseum/helm-push/releases/download/v{version}/helm-push_{version}_darwin_arm64.tar.gz"],
+        "windows-amd64": ["https://github.com/chartmuseum/helm-push/releases/download/v{version}/helm-push_{version}_windows_amd64.tar.gz"],
+    },
+    integrity = {
+        "linux-amd64": "sha256-KfH3E2mbR+PJwY1gtQVffA6LzBIh1mOcBX54fgi2Vqg=",
+        "darwin-arm64": "sha256-oKyCvUYCHt/LPcIj99ZaVP6PlpGPy7dgwTl/yo43SqI=",
+        "windows-amd64": "sha256-aFkN3IJXd8TVlJ/NY3v2sZ4Rerp644e02u0HNqboELw=",
+    },
+)
+
 helm_test = use_extension("@rules_helm//tests:test_extensions.bzl", "helm_test", dev_dependency = True)
 use_repo(
     helm_test,

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -63,17 +63,21 @@ helm_dev = use_extension(
 )
 helm_dev.plugin(
     name = "cm-push",
-    version = "0.10.4",
-    url_templates = {
-        "linux-amd64": ["https://github.com/chartmuseum/helm-push/releases/download/v{version}/helm-push_{version}_linux_amd64.tar.gz"],
-        "darwin-arm64": ["https://github.com/chartmuseum/helm-push/releases/download/v{version}/helm-push_{version}_darwin_arm64.tar.gz"],
-        "windows-amd64": ["https://github.com/chartmuseum/helm-push/releases/download/v{version}/helm-push_{version}_windows_amd64.tar.gz"],
-    },
     integrity = {
-        "linux-amd64": "sha256-KfH3E2mbR+PJwY1gtQVffA6LzBIh1mOcBX54fgi2Vqg=",
+        "darwin-amd64": "sha256-zUUHz8RskD/Oq5n1qKSmvRXp5FZek6CSkd8w9awSQas=",
         "darwin-arm64": "sha256-oKyCvUYCHt/LPcIj99ZaVP6PlpGPy7dgwTl/yo43SqI=",
+        "linux-amd64": "sha256-KfH3E2mbR+PJwY1gtQVffA6LzBIh1mOcBX54fgi2Vqg=",
+        "linux-arm64": "sha256-Y92zov8e7yjSH6X0aYY2xVtCAxUr2cbM+stO8JFBsNI=",
         "windows-amd64": "sha256-aFkN3IJXd8TVlJ/NY3v2sZ4Rerp644e02u0HNqboELw=",
     },
+    url_templates = {
+        "darwin-amd64": ["https://github.com/chartmuseum/helm-push/releases/download/v{version}/helm-push_{version}_darwin_amd64.tar.gz"],
+        "darwin-arm64": ["https://github.com/chartmuseum/helm-push/releases/download/v{version}/helm-push_{version}_darwin_arm64.tar.gz"],
+        "linux-amd64": ["https://github.com/chartmuseum/helm-push/releases/download/v{version}/helm-push_{version}_linux_amd64.tar.gz"],
+        "linux-arm64": ["https://github.com/chartmuseum/helm-push/releases/download/v{version}/helm-push_{version}_linux_arm64.tar.gz"],
+        "windows-amd64": ["https://github.com/chartmuseum/helm-push/releases/download/v{version}/helm-push_{version}_windows_amd64.tar.gz"],
+    },
+    version = "0.10.4",
 )
 
 helm_test = use_extension("@rules_helm//tests:test_extensions.bzl", "helm_test", dev_dependency = True)

--- a/helm/extensions.bzl
+++ b/helm/extensions.bzl
@@ -3,6 +3,7 @@
 load(
     "//helm/private:repositories.bzl",
     "helm_host_alias_repository",
+    "helm_plugin_repository",
     "helm_toolchain_repository",
     "helm_toolchain_repository_hub",
 )
@@ -35,6 +36,35 @@ def _helm_impl(module_ctx):
     host_tools = root_mod.tags.host_tools
     if not host_tools:
         host_tools = rules_mod.tags.host_tools
+
+    plugins = root_mod.tags.plugin
+
+    # Create plugin repos and build a map of platform -> plugin labels.
+    platform_plugins = {}
+    for plugin_attrs in plugins:
+        for platform, integrity in plugin_attrs.integrity.items():
+            plugin_repo_name = "helm_plugin_{}_{}".format(
+                plugin_attrs.name,
+                platform.replace("-", "_"),
+            )
+
+            helm_plugin_repository(
+                name = plugin_repo_name,
+                plugin_name = plugin_attrs.name,
+                urls = [
+                    template.replace("{version}", plugin_attrs.version)
+                    for template in plugin_attrs.url_templates[platform]
+                ],
+                integrity = integrity,
+                strip_prefix = plugin_attrs.strip_prefix,
+                yaml = plugin_attrs.yaml,
+            )
+
+            if platform not in platform_plugins:
+                platform_plugins[platform] = []
+            platform_plugins[platform].append(
+                "@{}//:{}".format(plugin_repo_name, plugin_attrs.name),
+            )
 
     toolchain_names = []
     toolchain_labels = {}
@@ -76,6 +106,7 @@ def _helm_impl(module_ctx):
                 integrity = integrity,
                 strip_prefix = url_platform,
                 platform = platform,
+                plugins = platform_plugins.get(platform, []),
             )
 
             toolchain_names.append(toolchain_repo_name)
@@ -129,9 +160,67 @@ use_repo(helm, "helm")
     },
 )
 
+_plugin = tag_class(
+    doc = """\
+An extension tag for declaring Helm plugins to include in all toolchains.
+
+Plugins are downloaded per-platform and wired into each generated helm_toolchain.
+Only platforms listed in `integrity` (and `url_templates`) will receive the plugin.
+
+An example of declaring the helm-diff plugin:
+
+```python
+helm = use_extension("@rules_helm//helm:extensions.bzl", "helm")
+helm.host_tools()
+helm.plugin(
+    name = "diff",
+    version = "3.15.5",
+    strip_prefix = "diff",
+    url_templates = {
+        "darwin-arm64": ["https://github.com/databus23/helm-diff/releases/download/v{version}/helm-diff-macos-arm64.tgz"],
+        "darwin-amd64": ["https://github.com/databus23/helm-diff/releases/download/v{version}/helm-diff-macos-amd64.tgz"],
+        "linux-amd64": ["https://github.com/databus23/helm-diff/releases/download/v{version}/helm-diff-linux-amd64.tgz"],
+        "linux-arm64": ["https://github.com/databus23/helm-diff/releases/download/v{version}/helm-diff-linux-arm64.tgz"],
+    },
+    integrity = {
+        "darwin-arm64": "sha256-KJmZ7wY3gAcWFzK5R9+TfQlaRfEXzJ7hDNRC8NgIDog=",
+        "linux-amd64": "sha256-ToJjCrKyMxfAOeezsWYF95qKwPPSKHPg1G6pzZgN2o4=",
+        "linux-arm64": "sha256-4tu/93Bo2T7VYgYj6oHyTYah7UQAuRmE1jgvSAEfaaM=",
+    },
+)
+```
+""",
+    attrs = {
+        "integrity": attr.string_dict(
+            doc = "A mapping of helm platform name to integrity hash. Only platforms listed here will receive the plugin.",
+            mandatory = True,
+        ),
+        "name": attr.string(
+            doc = "The name of the plugin.",
+            mandatory = True,
+        ),
+        "strip_prefix": attr.string(
+            doc = "A directory prefix to strip from the extracted plugin archive.",
+        ),
+        "url_templates": attr.string_list_dict(
+            doc = "Mapping of helm platform name to a list of URL templates for downloading the plugin on that platform. Only `{version}` is substituted; spell the platform name into the URL string directly. Every key in `integrity` must have a matching entry here.",
+            mandatory = True,
+        ),
+        "version": attr.string(
+            doc = "The version of the plugin to download.",
+            mandatory = True,
+        ),
+        "yaml": attr.string(
+            doc = "Relative path to plugin.yaml within the extracted archive (after strip_prefix).",
+            default = "plugin.yaml",
+        ),
+    },
+)
+
 helm = module_extension(
     implementation = _helm_impl,
     tag_classes = {
         "host_tools": _host_tools,
+        "plugin": _plugin,
     },
 )

--- a/helm/private/repositories.bzl
+++ b/helm/private/repositories.bzl
@@ -105,6 +105,70 @@ If all downloads fail, the rule will fail.
     },
 )
 
+_HELM_PLUGIN_BUILD_CONTENT = """\
+load("@rules_helm//helm:helm_plugin.bzl", "helm_plugin")
+
+package(default_visibility = ["//visibility:public"])
+
+helm_plugin(
+    name = "{name}",
+    yaml = "{yaml}",
+    data = glob(
+        include = ["**"],
+        exclude = [
+            "BUILD",
+            "BUILD.bazel",
+            "WORKSPACE",
+            "WORKSPACE.bazel",
+            "{yaml}",
+        ],
+    ),
+    plugin_name = "{name}",
+)
+"""
+
+def _helm_plugin_repository_impl(repository_ctx):
+    repository_ctx.download_and_extract(
+        repository_ctx.attr.urls,
+        integrity = repository_ctx.attr.integrity,
+        stripPrefix = repository_ctx.attr.strip_prefix,
+    )
+
+    repository_ctx.file("BUILD.bazel", _HELM_PLUGIN_BUILD_CONTENT.format(
+        name = repository_ctx.attr.plugin_name,
+        yaml = repository_ctx.attr.yaml,
+    ))
+
+    repository_ctx.file("WORKSPACE.bazel", _HELM_WORKSPACE_CONTENT.format(
+        repository_ctx.name,
+    ))
+
+helm_plugin_repository = repository_rule(
+    implementation = _helm_plugin_repository_impl,
+    doc = "A repository rule for downloading a Helm plugin and generating a helm_plugin target.",
+    attrs = {
+        "integrity": attr.string(
+            doc = "Expected checksum in Subresource Integrity format.",
+            mandatory = True,
+        ),
+        "plugin_name": attr.string(
+            doc = "The name of the helm plugin.",
+            mandatory = True,
+        ),
+        "strip_prefix": attr.string(
+            doc = "A directory prefix to strip from the extracted files.",
+        ),
+        "urls": attr.string_list(
+            doc = "URLs to download the plugin archive from.",
+            mandatory = True,
+        ),
+        "yaml": attr.string(
+            doc = "Relative path to plugin.yaml within the extracted archive (after strip_prefix).",
+            default = "plugin.yaml",
+        ),
+    },
+)
+
 def _platform(rctx):
     """Returns a normalized name of the host os and CPU architecture.
 

--- a/helm/private/toolchain.bzl
+++ b/helm/private/toolchain.bzl
@@ -95,7 +95,7 @@ def _helm_toolchain_impl(ctx):
     })
 
     default_info = DefaultInfo(
-        files = depset([binary]),
+        files = depset([binary, plugins_dir]),
         runfiles = ctx.runfiles(files = [binary, plugins_dir]),
     )
 

--- a/tests/bzlmod_plugin/BUILD.bazel
+++ b/tests/bzlmod_plugin/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+
+# Asserts that a plugin declared via the `helm.plugin` bzlmod tag is wired into
+# the helm toolchain. The genrule runs `helm plugin list` through the active
+# toolchain; if the plugin is missing, `grep` fails the action.
+genrule(
+    name = "cm_push_plugin_listed",
+    outs = ["cm_push_plugin_list.txt"],
+    cmd = "HELM_PLUGINS=$$PWD/$(HELM_PLUGINS) $(HELM_BIN) plugin list > $@ && grep -q '^cm-push' $@",
+    target_compatible_with = select({
+        "@platforms//os:linux": [],
+        "@platforms//os:macos": [],
+        "//conditions:default": ["@platforms//:incompatible"],
+    }),
+    testonly = True,
+    toolchains = ["@rules_helm//helm:current_toolchain"],
+)
+
+build_test(
+    name = "cm_push_plugin_listed_test",
+    targets = [":cm_push_plugin_listed"],
+)

--- a/tests/bzlmod_plugin/BUILD.bazel
+++ b/tests/bzlmod_plugin/BUILD.bazel
@@ -5,6 +5,7 @@ load("@bazel_skylib//rules:build_test.bzl", "build_test")
 # toolchain; if the plugin is missing, `grep` fails the action.
 genrule(
     name = "cm_push_plugin_listed",
+    testonly = True,
     outs = ["cm_push_plugin_list.txt"],
     cmd = "HELM_PLUGINS=$$PWD/$(HELM_PLUGINS) $(HELM_BIN) plugin list > $@ && grep -q '^cm-push' $@",
     target_compatible_with = select({
@@ -12,7 +13,6 @@ genrule(
         "@platforms//os:macos": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    testonly = True,
     toolchains = ["@rules_helm//helm:current_toolchain"],
 )
 


### PR DESCRIPTION
Adds a `helm.plugin()` module extension tag for declaring Helm plugins to bundle into all generated `helm_toolchain` targets, plus a `helm_plugin_repository` repo rule that downloads and extracts a plugin archive and emits a `helm_plugin` target consumable by the toolchain's existing plugins attr.

Plugins are downloaded per-platform; only platforms with an entry in the integrity dict receive the plugin.

Usage:
```py
# MODULE.bazel
helm = use_extension("@rules_helm//helm:extensions.bzl", "helm")
helm.plugin(
    name = "diff",
    version = "3.15.5",
    strip_prefix = "diff",
    url_templates = {
        "darwin-arm64": ["https://github.com/databus23/helm-diff/releases/download/v{version}/helm-diff-macos-arm64.tgz"],
        "linux-amd64":  ["https://github.com/databus23/helm-diff/releases/download/v{version}/helm-diff-linux-amd64.tgz"],
        "linux-arm64":  ["https://github.com/databus23/helm-diff/releases/download/v{version}/helm-diff-linux-arm64.tgz"],
    },
    integrity = {
        "darwin-arm64": "sha256-KJmZ7wY3gAcWFzK5R9+TfQlaRfEXzJ7hDNRC8NgIDog=",
        "linux-amd64":  "sha256-ToJjCrKyMxfAOeezsWYF95qKwPPSKHPg1G6pzZgN2o4=",
        "linux-arm64":  "sha256-4tu/93Bo2T7VYgYj6oHyTYah7UQAuRmE1jgvSAEfaaM=",
    },
)
```

This makes the diff plugin automatically available to all helm targets.
