### PR TITLE
Add support for registry_url_file

### DIFF
--- a/helm/private/helm.bzl
+++ b/helm/private/helm.bzl
@@ -21,6 +21,7 @@ def helm_chart(
         deps = None,
         install_name = None,
         registry_url = None,
+        registry_url_file = None,
         login_url = None,
         push_cmd = None,
         helm_opts = [],
@@ -39,8 +40,8 @@ def helm_chart(
     | `{name}` | [helm_package](#helm_package) | `None` |
     | `{name}.push_images` | [helm_push_images](#helm_push_images) | `None` |
     | `{name}.oci_digest` | [helm_oci_digest](#helm_oci_digest) | `None` |
-    | `{name}.push_registry` | [helm_push](#helm_push) (`include_images = False`) | `registry_url` is defined. |
-    | `{name}.push` | [helm_push](#helm_push) (`include_images = True`) | `registry_url` is defined. |
+    | `{name}.push_registry` | [helm_push](#helm_push) (`include_images = False`) | `registry_url` or `registry_url_file` is defined. |
+    | `{name}.push` | [helm_push](#helm_push) (`include_images = True`) | `registry_url` or `registry_url_file` is defined. |
     | `{name}.install` | [helm_install](#helm_install) | `None` |
     | `{name}.uninstall` | [helm_uninstall](#helm_uninstall) | `None` |
     | `{name}.upgrade` | [helm_upgrade](#helm_upgrade) | `None` |
@@ -60,7 +61,9 @@ def helm_chart(
         deps (list, optional): A list of helm package dependencies.
         install_name (str, optional): The `helm install` name to use. `name` will be used if unset.
         registry_url (str, Optional): The registry url for the helm chart. `{name}.push_registry`
-            is only defined when a value is passed here.
+            is only defined when a value is passed here. Mutually exclusive with `registry_url_file`.
+        registry_url_file (Label, Optional): A file containing the registry url for the helm chart.
+            `{name}.push_registry` is only defined when a value is passed here. Mutually exclusive with `registry_url`.
         login_url (str, optional): The registry url to log into for publishing helm charts.
         push_cmd (str, optional): An alternative command to `push` for publishing helm charts.
         helm_opts (list, optional): Additional options to pass to helm.
@@ -128,12 +131,16 @@ def helm_chart(
         **kwargs
     )
 
-    if registry_url:
+    if registry_url and registry_url_file:
+        fail("`registry_url` and `registry_url_file` are mutually exclusive. Only one may be specified for `helm_chart` target `{}`.".format(name))
+
+    if registry_url or registry_url_file:
         helm_push(
             name = name + ".push_registry",
             package = name,
             include_images = False,
             registry_url = registry_url,
+            registry_url_file = registry_url_file,
             login_url = login_url,
             opts = helm_opts + push_opts,
             push_cmd = push_cmd,
@@ -145,6 +152,7 @@ def helm_chart(
             include_images = True,
             package = name,
             registry_url = registry_url,
+            registry_url_file = registry_url_file,
             login_url = login_url,
             opts = helm_opts + push_opts,
             push_cmd = push_cmd,

--- a/helm/private/registrar/registrar.go
+++ b/helm/private/registrar/registrar.go
@@ -70,6 +70,7 @@ func main() {
 	rawChartPath := flag.String("chart", "", "Path to Helm .tgz file")
 	rawMetadataPath := flag.String("metadata", "", "Path to the chart metadata JSON file (with `created` field)")
 	registryURL := flag.String("registry_url", "", "URL of registry to upload helm chart")
+	rawRegistryURLFile := flag.String("registry_url_file", "", "Path to a file containing the URL of registry to upload helm chart")
 	rawLoginURL := flag.String("login_url", "", "URL of registry to login to.")
 	pushCmd := flag.String("push_cmd", "push", "Command to publish helm chart.")
 	rawImagePushers := flag.String("image_pushers", "", "Comma-separated list of image pusher executables")
@@ -79,8 +80,27 @@ func main() {
 	helmArgs := flag.CommandLine.Args()
 
 	// Check required arguments
-	if *rawHelmPath == "" || *rawChartPath == "" || *rawMetadataPath == "" || *registryURL == "" {
-		log.Fatalf("Missing required arguments: helm, chart, metadata, registry_url")
+	if *rawHelmPath == "" || *rawChartPath == "" || *rawMetadataPath == "" {
+		log.Fatalf("Missing required arguments: helm, chart, metadata")
+	}
+	if *registryURL != "" && *rawRegistryURLFile != "" {
+		log.Fatalf("`registry_url` and `registry_url_file` are mutually exclusive; only one may be specified")
+	}
+	if *registryURL == "" && *rawRegistryURLFile == "" {
+		log.Fatalf("Missing required argument: either `registry_url` or `registry_url_file` must be specified")
+	}
+
+	if *rawRegistryURLFile != "" {
+		registryURLFilePath := helm_utils.GetRunfile(*rawRegistryURLFile)
+		contents, err := os.ReadFile(registryURLFilePath)
+		if err != nil {
+			log.Fatalf("Failed to read registry_url_file %q: %v", registryURLFilePath, err)
+		}
+		registryURLValue := strings.TrimSpace(string(contents))
+		if registryURLValue == "" {
+			log.Fatalf("registry_url_file %q is empty", registryURLFilePath)
+		}
+		registryURL = &registryURLValue
 	}
 
 	helmPath := helm_utils.GetRunfile(*rawHelmPath)

--- a/helm/private/registry.bzl
+++ b/helm/private/registry.bzl
@@ -32,13 +32,26 @@ def _helm_push_impl(ctx):
 
     pkg_info = ctx.attr.package[HelmPackageInfo]
 
+    if ctx.attr.registry_url and ctx.attr.registry_url_file:
+        fail("`registry_url` and `registry_url_file` are mutually exclusive. Only one may be specified for target `{}`.".format(ctx.label))
+    if not ctx.attr.registry_url and not ctx.attr.registry_url_file:
+        fail("Either `registry_url` or `registry_url_file` must be specified for target `{}`.".format(ctx.label))
+
+    extra_runfiles = []
+
     args = ctx.actions.args()
     args.set_param_file_format("multiline")
     args.add("-helm", rlocationpath(toolchain.helm, ctx.workspace_name))
     args.add("-helm_plugins", rlocationpath(toolchain.helm_plugins, ctx.workspace_name))
     args.add("-chart", rlocationpath(pkg_info.chart, ctx.workspace_name))
     args.add("-metadata", rlocationpath(pkg_info.metadata, ctx.workspace_name))
-    args.add("-registry_url", ctx.attr.registry_url)
+
+    if ctx.attr.registry_url:
+        args.add("-registry_url", ctx.attr.registry_url)
+    if ctx.attr.registry_url_file:
+        registry_url_file = ctx.file.registry_url_file
+        args.add("-registry_url_file", rlocationpath(registry_url_file, ctx.workspace_name))
+        extra_runfiles.append(registry_url_file)
 
     if ctx.attr.login_url:
         args.add("-login_url", ctx.attr.login_url)
@@ -73,7 +86,7 @@ def _helm_push_impl(ctx):
         toolchain.helm_plugins,
         pkg_info.chart,
         pkg_info.metadata,
-    ]).merge(image_runfiles)
+    ] + extra_runfiles).merge(image_runfiles)
 
     return [
         DefaultInfo(
@@ -124,8 +137,11 @@ if the following environment variables are defined:
             doc = "An alternative command to `push` for publishing the helm chart. E.g. `cm-push`",
         ),
         "registry_url": attr.string(
-            doc = "The registry URL at which to push the helm chart to. E.g. `oci://my.registry.io/chart-name`",
-            mandatory = True,
+            doc = "The registry URL at which to push the helm chart to. E.g. `oci://my.registry.io/chart-name`. Mutually exclusive with `registry_url_file`.",
+        ),
+        "registry_url_file": attr.label(
+            doc = "A file containing the registry URL at which to push the helm chart to. Mutually exclusive with `registry_url`.",
+            allow_single_file = True,
         ),
         "_copier": attr.label(
             cfg = "exec",

--- a/tests/simple/BUILD.bazel
+++ b/tests/simple/BUILD.bazel
@@ -1,9 +1,23 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
-load("//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_template", "helm_template_test")
+load("//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_push", "helm_template", "helm_template_test")
 
 helm_chart(
     name = "simple",
     registry_url = "oci://localhost/helm-registry",
+)
+
+# Smoke-test for the `registry_url_file` attribute. Ensures the rule analyzes
+# and builds correctly when a file is used instead of a literal URL.
+genrule(
+    name = "simple_registry_url_file",
+    outs = ["simple_registry_url.txt"],
+    cmd = "echo oci://localhost/helm-registry > $@",
+)
+
+helm_push(
+    name = "simple.push_from_file",
+    package = ":simple",
+    registry_url_file = ":simple_registry_url_file",
 )
 
 helm_lint_test(


### PR DESCRIPTION
Like in #264 , need support for registry substitution in the helm push rule