### PR TITLE
Populate registry and project fields into helm package

### DIFF
--- a/helm/private/packager/packager.go
+++ b/helm/private/packager/packager.go
@@ -329,6 +329,7 @@ func loadImageStamps(imageManifestPath string) ([]ReplacementGroup, error) {
 		workspaceLabel := strings.Replace(imageInfo.Label, "@@", "@", 1)
 		bzmodLabel := fmt.Sprintf("@%s", imageInfo.Label)
 		imageUrl := fmt.Sprintf("%s@%s", repository, digest)
+		repoSegments := strings.Split(repository, "/")
 
 		replacements := map[string]string{
 			workspaceLabel:                 imageUrl,
@@ -337,6 +338,14 @@ func loadImageStamps(imageManifestPath string) ([]ReplacementGroup, error) {
 			bzmodLabel:                     imageUrl,
 			bzmodLabel + ".repository":     repository,
 			bzmodLabel + ".digest":         digest,
+		}
+		if len(repoSegments) > 0 {
+			replacements[workspaceLabel+".registry"] = repoSegments[0]
+			replacements[bzmodLabel+".registry"] = repoSegments[0]
+		}
+		if len(repoSegments) > 1 {
+			replacements[workspaceLabel+".project"] = strings.Join(repoSegments[1:], "/")
+			replacements[bzmodLabel+".project"] = strings.Join(repoSegments[1:], "/")
 		}
 		if tag != "" {
 			replacements[workspaceLabel+".tag"] = tag

--- a/tests/with_image_deps_img/BUILD.bazel
+++ b/tests/with_image_deps_img/BUILD.bazel
@@ -21,6 +21,7 @@ helm_chart(
         ":image_c.push",
         ":image_d.push",
         ":image_e.push",
+        ":image_f.push",
     ],
     target_compatible_with = EXCLUDE_WINDOWS,
 )
@@ -47,6 +48,7 @@ helm_package_regex_test(
         r"image_c:\s+url:\s+\"docker.io/rules_helm/test_img/image_c:1.2.3\"",
         r"image_d:\s+url:\s+\"docker.io/rules_helm/test_img/image_d:4.5.6\"",
         r"image_e:\s+url:\s+\"docker.io/rules_helm/test_img/image_e:7.8.9\"",
+        r"image_f:\s+url:\s+\"docker.io/rules_helm/test_img/image_f@sha256:[a-z0-9]{64}\"",
     ],
 )
 
@@ -56,6 +58,7 @@ _IMAGES = [
     "image_c",
     "image_d",
     "image_e",
+    "image_f",
 ]
 
 # Create simple image layers and manifests for each test image
@@ -150,5 +153,14 @@ image_push(
     registry = "{{ .registry }}",
     repository = "{{ .repository }}",
     tag = "{{ .tag }}",
+    target_compatible_with = EXCLUDE_WINDOWS,
+)
+
+image_push(
+    name = "image_f.push",
+    image = ":image_f",
+    registry = "docker.io",
+    repository = "rules_helm/test_img/image_f",
+    tag_list = ["latest"],
     target_compatible_with = EXCLUDE_WINDOWS,
 )

--- a/tests/with_image_deps_img/values.yaml
+++ b/tests/with_image_deps_img/values.yaml
@@ -21,6 +21,8 @@ bazel_produced_images:
     url: "{@//tests/with_image_deps_img:image_d.push.repository}:{@//tests/with_image_deps_img:image_d.push.tag}"
   image_e:
     url: "{@//tests/with_image_deps_img:image_e.push.repository}:{@//tests/with_image_deps_img:image_e.push.tag}"
+  image_f:
+    url: "{@//tests/with_image_deps_img:image_f.push.registry}/{@//tests/with_image_deps_img:image_f.push.project}@{@//tests/with_image_deps_img:image_e.push.digest}"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Proposal
Add a new `helm_package` replacements that represents separate `registry` and `project` in repository URL
For ex. localhost:5000/project-dir/image-name
- localhost:5000 is a `registry` endpoint
- project-dir/image-name is a `project` name

The entire URL remains being represented by the `repository` replacement.

## Goal
Big projects have cross-registry/cross-region replication configured in 99% of cases. The only part what is really changed is registry endpoint while the project part remains the same.