### PR TITLE
fix: return a valid canonical reproducible form from helm_import_repository

### DIFF
--- a/helm/private/import.bzl
+++ b/helm/private/import.bzl
@@ -191,12 +191,18 @@ def _helm_import_repository_impl(repository_ctx):
         repository_name = repository_ctx.name,
     ))
 
+    if repository_ctx.attr.url:
+        return {
+            "name": repository_ctx.name,
+            "sha256": result.sha256,
+            "url": chart_url,
+        }
+
     return {
         "chart_name": chart_name,
         "name": repository_ctx.name,
         "repository": repository_ctx.attr.repository,
         "sha256": result.sha256,
-        "url": chart_url,
         "version": chart_version,
     }
 


### PR DESCRIPTION
## Issue

`helm_import_repository`'s implementation returns the dict Bazel treats as the repository's "canonical reproducible form". Bazel compares each returned attribute against the declared one and emits a `DEBUG` message suggesting the user add any that differ.

`url` is mutually exclusive with `repository` / `chart_name` / `version` (the rule `fail()`s if both are set), but the implementation returned all of them unconditionally. So the suggested form is one the rule itself rejects:

- importing via **`url`** → suggests adding `chart_name` / `version`
- importing via **`repository`** → suggests adding `url`

Either way the user gets a confusing, unactionable `DEBUG` message. Fixes #189.

```
DEBUG: Rule '...' indicated that a canonical reproducible form can be obtained
by modifying arguments chart_name = "grafana", version = "12.1.4"
```

## Change

Return only the attributes matching the source type actually used, so the suggested reproducible form is always a valid re-declaration:

- `url` mode → `{name, url, sha256}`
- `repository` mode → `{name, repository, chart_name, version, sha256}`

## Testing

Verified with `bazel fetch --repo=@... --force` against the charts already in `tests/test_deps.bzl`:

| Chart | Source | Before | After |
|---|---|---|---|
| `postgresql` | `url=` (http) | DEBUG suggests `chart_name`/`version` | clean |
| `grafana` | `url=` (oci) | DEBUG suggests `chart_name`/`version` | clean |
| `redis` | `repository=` | DEBUG suggests `url` | clean |

Fixes #189