### PR TITLE
feat: adopt repository_ctx.repo_metadata for Bazel 9

### DIFF
--- a/helm/private/import.bzl
+++ b/helm/private/import.bzl
@@ -192,19 +192,29 @@ def _helm_import_repository_impl(repository_ctx):
     ))
 
     if repository_ctx.attr.url:
-        return {
+        attrs_for_reproducibility = {
             "name": repository_ctx.name,
             "sha256": result.sha256,
             "url": chart_url,
         }
+    else:
+        attrs_for_reproducibility = {
+            "chart_name": chart_name,
+            "name": repository_ctx.name,
+            "repository": repository_ctx.attr.repository,
+            "sha256": result.sha256,
+            "version": chart_version,
+        }
 
-    return {
-        "chart_name": chart_name,
-        "name": repository_ctx.name,
-        "repository": repository_ctx.attr.repository,
-        "sha256": result.sha256,
-        "version": chart_version,
-    }
+    # Bazel <8.3.0 lacks repository_ctx.repo_metadata
+    if not hasattr(repository_ctx, "repo_metadata"):
+        return attrs_for_reproducibility
+
+    reproducible = repository_ctx.attr.sha256 != ""
+    return repository_ctx.repo_metadata(
+        reproducible = reproducible,
+        attrs_for_reproducibility = {} if reproducible else attrs_for_reproducibility,
+    )
 
 helm_import_repository = repository_rule(
     implementation = _helm_import_repository_impl,

--- a/helm/private/import.bzl
+++ b/helm/private/import.bzl
@@ -191,12 +191,18 @@ def _helm_import_repository_impl(repository_ctx):
         repository_name = repository_ctx.name,
     ))
 
+    if repository_ctx.attr.url:
+        return {
+            "name": repository_ctx.name,
+            "sha256": result.sha256,
+            "url": chart_url,
+        }
+
     return {
         "chart_name": chart_name,
         "name": repository_ctx.name,
         "repository": repository_ctx.attr.repository,
         "sha256": result.sha256,
-        "url": chart_url,
         "version": chart_version,
     }
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #285. That PR fixes the *contents* of the reproducibility dict, this one changes the *mechanism* used to return it. Review/merge after #285 (or together).

## Issue

Bazel 9 deprecates returning a bare dict from a repository rule implementation in favor of [`repository_ctx.repo_metadata`](https://bazel.build/rules/lib/builtins/repository_ctx#repo_metadata). Beyond replacing the dict, `repo_metadata` lets a repo declare itself **reproducible**.

`helm_import_repository` already resolves a `sha256` for every fetch. A chart pinned by `sha256` is reproducible by definition, so we mark it `reproducible = True`. When no `sha256` was supplied we instead advertise the resolved one via `attrs_for_reproducibility`, exactly as the legacy bare-dict return did.

The call is guarded with `hasattr`, matching the approach in https://github.com/bazel-contrib/rules_python/pull/3597 and https://github.com/bazel-contrib/rules_multitool/pull/123: `repo_metadata` was only added in Bazel 8.3.0, and this project still supports Bazel 7.x in CI.

## Testing

Verified with `bazel fetch --repo=@... --force` on Bazel 9.1.0 against the charts in `tests/test_deps.bzl`:

| Scenario | Result |
|---|---|
| `postgresql`/`grafana`/`redis` with `sha256` | `reproducible = True`, no DEBUG, fetch cached |
| `postgresql` with `sha256` removed | DEBUG correctly suggests adding `sha256 = "..."`, fetch succeeds |